### PR TITLE
[Create] 싱글톤 및 매니저 관리 구조 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,14 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+
+
+
+
+# Mac file setting
+.DS_Store
+
+# Rider
+.idea/
+

--- a/Assets/LDH.meta
+++ b/Assets/LDH.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a298d8104011d4c6a90b65edeacff95f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LDH/LDH_Scripts.meta
+++ b/Assets/LDH/LDH_Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71d95f44f1c8a49689f4e15adc6f599d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LDH/LDH_Scripts/DesignPattern.meta
+++ b/Assets/LDH/LDH_Scripts/DesignPattern.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e6800bad1f014b519dcf20dc58ae221
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LDH/LDH_Scripts/DesignPattern/Singleton.cs
+++ b/Assets/LDH/LDH_Scripts/DesignPattern/Singleton.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DesignPattern
+{
+    /// ===================================================
+    /// - MoneBehaviour 기반 싱글톤 패턴
+    /// - Instance 접근자를 통해 인스턴스 접근 가능
+    /// - 상속한 클래스의 Awkae에서 SingletonInit() 호출이 필수적으로 필요
+    /// - Release() 수동 해제 가능
+    ///
+    /// 주의사항
+    /// - 반드시  SingletonInit() 반드시 호출!!
+    /// - Manager 클래스에 접근자(static) 등록 필요
+    /// - @Manager 프리팹에 붙이거나 AddComponent로 초기화 보장해야 함
+    /// ===================================================
+    public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
+    {
+        protected static T _instance;
+
+        public static T Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = FindObjectOfType<T>();
+                    DontDestroyOnLoad(_instance);
+                }
+
+                return _instance;
+            }
+        }
+
+        
+        /// <summary>
+        /// 싱글톤 초기화 (Awake에서 반드시 호출)
+        /// </summary>
+        protected void SingletonInit()
+        {
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+           
+            _instance = this as T;
+            DontDestroyOnLoad(_instance);
+        }
+        
+        /// <summary>
+        /// 싱글톤 수동 해제
+        /// </summary>
+        public static void Release()
+        {
+            if (_instance != null)
+            {
+                Destroy(_instance.gameObject);
+                _instance = null;
+            }
+        }
+        
+    }
+}

--- a/Assets/LDH/LDH_Scripts/DesignPattern/Singleton.cs.meta
+++ b/Assets/LDH/LDH_Scripts/DesignPattern/Singleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b665e1e8284c942ad8c2f17885d9e18b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LDH/LDH_Scripts/Managers.meta
+++ b/Assets/LDH/LDH_Scripts/Managers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cbb32de1dafc64ed8860670063b32c27
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LDH/LDH_Scripts/Managers/Manager.cs
+++ b/Assets/LDH/LDH_Scripts/Managers/Manager.cs
@@ -1,0 +1,59 @@
+using Test;
+using UnityEngine;
+
+namespace Managers
+{
+    /// ===================================================
+    /// 역할
+    /// - 프로젝트 내 Manager 클래스들을 중앙에서 관리
+    /// - @Manager 프리팹 하나만으로 모든 매니저 컴포넌트 로드 및 DontDestroyOnLoad
+    ///   - static 프로퍼티로 각 매니저 접근 가능
+    ///
+    /// 
+    /// 매니저 등록 방법
+    /// 1. Manager.cs에 static 프로퍼티 추가
+    ///     public static TestManager Test => TestManager.Instance;
+    /// 2.각 매니저 클래스는 Singleton<T> 상속 + Awake에서 SingletonInit() 호출해주기
+    ///     public class TestManager : Singleton<TestManager>
+    ///     {
+    ///         private void Awake() => SingletonInit();
+    ///     }
+    ///
+    /// 3. 해당 매니저 컴포넌트는 @Manager 프리팹에 다음 중 하나의 방식으로 등록한다 :
+    ///     - 프리팹 에디터에서 직접 컴포넌트를 추가 (프리팹 위치 : Assets/Resources/Prefabs/@Manager)
+    ///     - 또는 Manager.cs의 Initialize() 내에서 manager.AddComponent<T>로 동적으로 추가
+    ///
+    /// 사용 예시
+    /// Manager.Test.DebugTest();
+    /// 
+    /// 주의사항
+    /// - @Manager 오브젝트는 게임 실행 시 자동으로 초기화되기 때문에 씬에 배치할 필요가 없다.
+    /// 
+    /// ===================================================
+    
+    public static class Manager
+    {
+        public static GameObject manager;
+        
+        
+        //---- 접근용 프로퍼티 등록 ----- //
+        //예시) TestManager
+        public static TestManager Test => TestManager.Instance;
+        
+        
+        
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void Initialize()
+        {
+            var prefab = Resources.Load<GameObject>("Prefabs/@Manager");
+            manager = GameObject.Instantiate(prefab);
+            manager.gameObject.name = "@Manager";
+            GameObject.DontDestroyOnLoad(manager);
+                    
+            //각각의 매니저 스크립트를 프리팹에 스크립트를 직접 추가해두거나 아래와 같이 AddComponent로 동적으로 추가한다.
+            manager.AddComponent<TestManager>();
+            
+        }
+    }
+}
+

--- a/Assets/LDH/LDH_Scripts/Managers/Manager.cs.meta
+++ b/Assets/LDH/LDH_Scripts/Managers/Manager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 288f78b218f8044af9d65310b0d90bdf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LDH/LDH_Scripts/Test.meta
+++ b/Assets/LDH/LDH_Scripts/Test.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 394a494b44084a8eba7be153100147fb
+timeCreated: 1753163559

--- a/Assets/LDH/LDH_Scripts/Test/TestManager.cs
+++ b/Assets/LDH/LDH_Scripts/Test/TestManager.cs
@@ -1,0 +1,17 @@
+using System;
+using DesignPattern;
+using UnityEngine;
+
+namespace Test
+{
+    public class TestManager : Singleton<TestManager>
+    {
+        //원하는 시점에 싱글톤 초기화 진행
+        private void Awake() => SingletonInit();
+
+        public void DebugTest()
+        {
+            Debug.Log("[테스트 매니저] - DebugTest 호출");
+        }
+    }
+}

--- a/Assets/LDH/LDH_Scripts/Test/TestManager.cs.meta
+++ b/Assets/LDH/LDH_Scripts/Test/TestManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 649664ecaa7e456182f9ec9334c1e1e5
+timeCreated: 1753163586

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab3b40a022bbb4b22990d3fea3fdf03c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs.meta
+++ b/Assets/Resources/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 971d8122b8eec4814bd896c29f680ce8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/@Manager.prefab
+++ b/Assets/Resources/Prefabs/@Manager.prefab
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7444357794774398465
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8001251842576536872}
+  m_Layer: 0
+  m_Name: '@Manager'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8001251842576536872
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7444357794774398465}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Resources/Prefabs/@Manager.prefab.meta
+++ b/Assets/Resources/Prefabs/@Manager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9dac9c680ed2043c4937bf6132b3fe3d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 🔥 작업 내용 요약
- Feature :
  - 기능 요약 : 싱글톤 및 매니저 관리 구조 구축, @Manager 프리팹 추가
  - 구현 내용 :
     - Singleton<T> 클래스: MonoBehaviour 기반 싱글톤 패턴 구현
     - Manager.cs: 매니저 프리팹 로드 및 각 매니저 통합 관리
     - TestManager: 싱글톤 예제 매니저 작성 및 DebugTest 메서드 추가
     - @Manager 프리팹: 매니저 통합 관리용 프리팹 추가

- Docs :
  - .gitignore에 mac, rider 설정 파일 추가

## 🧪 테스트 방법
- 에디터에서 직접 실행하여 @Manager 프리팹이 인스턴스화 되는지 확인
- DontDestroyOnLoad가 적용되는지 확인


## 🤝 관련 이슈
- 없음

## ✅ 체크리스트
- [x] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항
- 자세한 사용 방법 및 설명은 각 클래스 주석에 상세히 적어두었습니다.
- 주요 주의사항 :
   - 싱글톤 상속한 매니저들은 반드시 Awake()에서 SingletonInit() 호출 필요
   - @Manager 프리팹 위치: Assets/Resources/Prefabs/@Manager
   - 추후 매니저 추가 시 Manager.cs에 static 프로퍼티 등록 필수
- 싱글톤 구조 관련해서 변경이나 제안사항 있으면 편하게 공유해주세요. 같이 논의하고 개선해보면 좋을 것 같습니다.

