### PR TITLE
[Fix] 총 매니저 및 게임 매니저 오류 수정

### DIFF
--- a/Assets/CYE/Scripts/GunManager.cs
+++ b/Assets/CYE/Scripts/GunManager.cs
@@ -8,20 +8,27 @@ using Managers;
 
 public enum BulletType
 {
-    blank, live
+    blank = 1, live = 2
 }
 
 public class GunManager : Singleton<GunManager>
 {
+    #region >> Constants
     private const int BULLET_MIN_COUNT = 1; // 최소 총일 갯수 2개(공포탄 1개, 실탄 1개)
     private const int BULLET_MAX_COUNT = 4; // 최대 총알 갯수 8개(공포탄 4개, 실탄 4개)
     private const int BASE_DAMAGE = 1;
+    #endregion
 
-    private Queue<BulletType> _magazine = new(BULLET_MAX_COUNT * Enum.GetValues(typeof(BulletType)).Length); // capacity 지정
+    #region >> Variables
+    private Queue<BulletType> _magazine = new(BULLET_MAX_COUNT * Enum.GetValues(typeof(BulletType)).Length);
     public Queue<BulletType> Magazine { get { return _magazine; } private set { _magazine = value; } }
     private BulletType _loadedBullet; // 현재 장전된 탄환
+    public BulletType LoadedBullet { get{ return _loadedBullet; } private set { _loadedBullet = value; } }
     private bool _isEnhanced;
+    public bool IsEnhanced { get { return _isEnhanced; } set { _isEnhanced = value; } }
+    #endregion
 
+    #region  >> Unity Message Function
     private void Awake() => Init();
 
     private void Init()
@@ -30,7 +37,78 @@ public class GunManager : Singleton<GunManager>
         _isEnhanced = false;
         Manager.Game.OnTurnStart += Reload;
     }
-    public void Fire(GamePlayer target)
+    #endregion
+
+    #region >> Public Function
+    // public void Fire(GamePlayer target) => FireGunToTarget(target);
+    // {
+    //     if (_loadedBullet == BulletType.live)
+    //     {
+    //         int damage = _isEnhanced ? BASE_DAMAGE * 2 : BASE_DAMAGE;
+    //         target.DecreaseHp(damage);
+    //     }
+    //     // TO DO: 탄피 배출 연출 실행
+    //     _isEnhanced = false;
+    //     _magazine.TryDequeue(out _loadedBullet);
+    // }
+    public void Fire(string playerId)
+    {
+        GamePlayer target = Manager.PlayerManager.GetAllPlayers()[playerId];
+        if (!target)
+        {
+            Debug.Log($"{playerId}에 해당하는 플레이어를 찾을 수 없습니다.");
+            return;            
+        }        
+        FireGunToTarget(target);
+    }
+
+    public void Reload()
+    {
+        // TO DO: 해당 함수 사용처에서 충분히 테스트가 진행되었다면 다시 하단의 조건을 주석 해제하여야한다.
+        if (_magazine.Count <= 0 && _loadedBullet == default)
+        {
+            BulletType[] bulletTypeCountPreSet = ConvertCountDictToArray(GetRandomBulletCount());
+            // TO DO: 재장전 연출 실행(반드시 ShuffleBullets 호출 전에 실행하여야 한다.)
+            foreach (BulletType bullet in ShuffleBullets(bulletTypeCountPreSet))
+            {
+                Debug.Log($"장전 >> {bullet}");
+                _magazine.Enqueue(bullet);
+            }
+            if (!_magazine.TryDequeue(out _loadedBullet))
+            {
+                Debug.Log("장전 실패.");
+                _loadedBullet = default;
+                return;
+            }
+        }
+    }
+
+    public void SwitchNextBullet()
+    {
+        int loopCnt = 0, maxLoop = 10;
+        BulletType switchBullet = _loadedBullet;
+        while (switchBullet == _loadedBullet && loopCnt < maxLoop)
+        {
+            switchBullet = (BulletType)new System.Random().Next(0, Enum.GetValues(typeof(BulletType)).Length);
+            loopCnt++;
+        }
+        if (loopCnt >= maxLoop)
+        {
+            Debug.Log($"next bullet 변경 실패.");
+            return;
+        }
+        _loadedBullet = switchBullet;
+    }
+
+    public BulletType GetBulletTypeByIndex(int index)
+    {
+        BulletType[] _magazineArray = _magazine.ToArray();
+        return (index == 0) ? _loadedBullet : _magazineArray[index - 1];
+    }
+    #endregion
+
+    #region >> Private Function
+    private void FireGunToTarget(GamePlayer target)
     {
         if (_loadedBullet == BulletType.live)
         {
@@ -39,32 +117,14 @@ public class GunManager : Singleton<GunManager>
         }
         // TO DO: 탄피 배출 연출 실행
         _isEnhanced = false;
-        _magazine.TryDequeue(out _loadedBullet);
-    }
-    public void Reload()
-    {
-        // if (_magazine.Count <= 0)
+        if (!_magazine.TryDequeue(out _loadedBullet))
         {
-            Dictionary<BulletType, int> bulletTypeCountSet = GetRandomBulletCount();
-            // TO DO: 재장전 연출 실행
-            foreach (BulletType bullet in ShuffleBullets(bulletTypeCountSet))
-            {
-                Debug.Log($"{bullet}");
-                _magazine.Enqueue(bullet);
-            }
+            _loadedBullet = default;
         }
     }
-    private BulletType[] ShuffleBullets(Dictionary<BulletType, int> bulletTypeCountSet)
+
+    private BulletType[] ShuffleBullets(BulletType[] bulletSet)
     {
-        List<BulletType> preSet = new();
-        foreach (KeyValuePair<BulletType, int> item in bulletTypeCountSet)
-        {
-            for (int cnt = 0; cnt < item.Value; cnt++)
-            {
-                preSet.Add(item.Key);
-            }
-        }
-        BulletType[] bulletSet = preSet.ToArray();
         for (int cnt = 0; cnt < bulletSet.Length; cnt++)
         {
             int changeIndex = new System.Random().Next(0, cnt + 1);
@@ -72,6 +132,7 @@ public class GunManager : Singleton<GunManager>
         }
         return bulletSet;
     }
+
     private Dictionary<BulletType, int> GetRandomBulletCount()
     {
         Dictionary<BulletType, int> result = new();
@@ -81,26 +142,18 @@ public class GunManager : Singleton<GunManager>
         }
         return result;
     }
-    public void SwitchNextBullet()
+
+    private BulletType[] ConvertCountDictToArray(Dictionary<BulletType, int> bulletTypeCountSet)
     {
-        // 현재 동작 안함
-        int loopCnt = 0, maxLoop = 10;
-        BulletType switchBullet = _loadedBullet;
-        BulletType[] types = (BulletType[])Enum.GetValues(typeof(BulletType));
-        while (switchBullet != _loadedBullet || loopCnt >= maxLoop)
+        List<BulletType> preSet = new();
+        foreach (KeyValuePair<BulletType, int> item in bulletTypeCountSet)
         {
-            switchBullet = (BulletType)new System.Random().Next(0, types.Length);
-            loopCnt++;
+            for (int cnt = 0; cnt < item.Value; cnt++)
+            {
+                preSet.Add(item.Key);
+            }
         }
-        if (loopCnt >= maxLoop)
-        {
-            Debug.Log($"next bullet 변경 실패.");
-            return;
-        }
-        else
-        {
-            Debug.Log($"{_loadedBullet}");
-            _loadedBullet = switchBullet;
-        }
+        return preSet.ToArray();
     }
+    #endregion
 }


### PR DESCRIPTION
## 🔥 작업 내용 요약
### InGameManager
- Bugfix : 턴 종료시 특정 조건에 따라 게임 종료가 실행되는 현상 수정
  - 버그 내용 : 턴 종료시 현재 체력이 0인 플레이어가 있을 경우 라운드 종료를 해야하는데 게임 종료가 실행되는 현상
  - 해결 방안 : 함수가 잘못 지정되어 있었음.
 - Refactor : player 목록을 PlayerManager에서 가져오도록 변경
  - 작업 내용 : 현재 player 목록을 호출하는 부분을 InGameManager에서 선언한 변수를 사용하는것이 아닌, PlayerManager에서 가져올 수 있도록 변경(player 목록 관리를 PlayerManager에 위임)
  - 리펙토링 의도 : InGameManager의 기능을 보다 명확하게 하고, 관련 데이터가 분산되지 않도록 함.
### GunManager
- Feature : 특정 순서에 해당하는 탄환 정보 확인 기능 추가
  - 기능 요약 : 확인하려는 탄환의 순번(int)을 지정하여 호출하면 해당 순번의 탄환 타입을 반환함.
  - 구현 내용 : 일시적으로 queue를 array로 변환하여 해당 index에 해당하는 탄환 타입을 변환함.(0->현재 장전된 탄환 반환(첫번째 탄환 반환), 1~->_magazine에 저장된 데이터를 반환함(두번째 탄환부터 반환/호출하려는 index는 배열의 index 형식을 따름(0부터 시작))
- Bugfix : 장전된 탄환 변경 기능 미작동 현상 수정
  - 버그 내용 : 장전된 탄환 변경 함수(SwitchNextBullet)를 호출해도 다음 탄이 변경되지 않는 현상 수정
  - 해결 방안 : 재장전시 맨 처음 탄환을 장전된 탄환으로 지정하지 않아서 발생함. 따라서 재장전시 맨 처음 탄환을 Dequeue하여 _loadedBullet에 지정하였음.
- Refactor : 재장전시 실행되는 함수 기능 분리
  - 작업 내용 : 재장전시 실행되는 함수 중 하나인 ShuffleBullets에서 실행되는 내용중 Dictionary를 셔플이 가능한 배열형태로 변환하는 로직을 별도의 함수로 분리하여 호출하도록 변경
  - 리펙토링 의도 : 셔플이 진행되기 이전의 배열값에 대한 사용이 필요하다고 판단하여 두 기능을 분리하였음.

## 🧪 테스트 방법
- 개인 테스트 Scene에서 테스트 진행

## 🤝 관련 이슈
- 없음

## ✅ 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항
- 

