### PR TITLE
[Fix] 플레이어 ID 관련 버그 및 기타 수정

### DIFF
--- a/Assets/PMS/PMS_Scene/PMS_StartScene.unity
+++ b/Assets/PMS/PMS_Scene/PMS_StartScene.unity
@@ -1,0 +1,385 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1618370144
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1618370146}
+  - component: {fileID: 1618370145}
+  - component: {fileID: 1618370147}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1618370145
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1618370144}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1618370146
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1618370144}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &1618370147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1618370144}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!1 &1987815105
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1987815107}
+  - component: {fileID: 1987815106}
+  m_Layer: 0
+  m_Name: NetworkManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1987815106
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987815105}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f2421b509d89f144ab94b33a4729e8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1987815107
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987815105}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2013341479
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2013341482}
+  - component: {fileID: 2013341481}
+  - component: {fileID: 2013341480}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2013341480
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2013341479}
+  m_Enabled: 1
+--- !u!20 &2013341481
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2013341479}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2013341482
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2013341479}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 2013341482}
+  - {fileID: 1618370146}
+  - {fileID: 1987815107}

--- a/Assets/PMS/PMS_Scene/PMS_StartScene.unity.meta
+++ b/Assets/PMS/PMS_Scene/PMS_StartScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7df273c870a01c64c8aba8d8110072cb
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PMS/PMS_Scripts/GamePlayer.cs
+++ b/Assets/PMS/PMS_Scripts/GamePlayer.cs
@@ -88,9 +88,6 @@ public class GamePlayer : MonoBehaviour, IComparer<GamePlayer>
     {
         if (_pv.IsMine)
         {
-            // 자신의 GamePlayer 객체를 PlayerManager에 등록
-            PlayerManager.Instance.RegisterPlayer(this);  
-
             //테스트 코드
             //일단 지금 당장 순서 보장해주기 힘드니깐 정렬을 사용해보자
             StartCoroutine(PlayerListPirntDelay());           

--- a/Assets/PMS/PMS_Scripts/InGamePlayerManager.cs
+++ b/Assets/PMS/PMS_Scripts/InGamePlayerManager.cs
@@ -1,36 +1,135 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Photon.Pun;
 using System.IO;
+using UnityEngine.SceneManagement;
 
-    //이친구를 생성을 하고 
-public class InGamePlayerManager : MonoBehaviourPunCallbacks
+//Player생성 관리 - 싱글톤
+public class InGamePlayerManager : MonoBehaviour
 {
+    public static InGamePlayerManager Instance;
     private PhotonView _pv;
    
     private string key = "GameStart";
     private bool flag = false;
 
     public PlayerData _playerData;
+
+    //생성시점이 플레이어 룸에 들어왔을 때
     private void Awake()
     {
+        // 인스턴스가 없으면 자신을 인스턴스로 지정
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject); // 씬 전환 시 파괴 방지
+        }
+        else
+        {
+            Destroy(gameObject); // 중복된 싱글톤이 생기면 삭제
+        }
         _pv = GetComponent<PhotonView>();
     }
 
+    /*
     public override void OnRoomPropertiesUpdate(ExitGames.Client.Photon.Hashtable propertiesThatChanged)
     {
         if (_pv.IsMine && 
             propertiesThatChanged.ContainsKey(key) &&
             (bool)propertiesThatChanged[key] == true)
-        {
+    }*/
+
+    private void Update()
+    {
+        /*
+        //스폰매니저가 초기화가 완료 됬고 InGame씬으로 넘어왔을 때
+        if (_pv.IsMine && SceneManager.GetActiveScene().name == "PMS_TestScene") // && SpawnManager.Instance.IsSpawnInitFinished == true)
             CreateController();
-        }
+        */
     }
+
+    #region 마스터 클라이언트 기준 Spawn - 버그있음
+    /*public void MasterClientSpawnAllPlayers()
+    {
+        if (!PhotonNetwork.IsMasterClient)
+        {
+            Debug.LogWarning("MasterClientSpawnAllPlayers는 마스터 클라이언트에서만 호출되어야 함.");
+            return;
+        }
+
+        Debug.Log("마스터 클라이언트가 모든 플레이어를 생성");
+
+        // 룸에 있는 모든 플레이어를 순회하는데 먼저 들어온 사람이 앞에존재
+        foreach (Photon.Realtime.Player photonPlayer in PhotonNetwork.PlayerList)
+        {
+            // 각 플레이어에 대한 고유한 스폰 포인트를 얻습니다.
+            // SpawnManager는 이미 사용된 스폰 포인트를 다시 반환하지 않도록 구현되어야 합니다.
+            (Transform playerSpawnPos, int playerSpawnIndex) = SpawnManager.Instance.GetAndClaimRandomSpawnPoint();
+
+            if (playerSpawnPos == null)
+            {
+                Debug.LogError($"플레이어 {photonPlayer.NickName}을 위한 스폰 포인트가 null입니다! 생성할 수 없습니다.");
+                continue; // 스폰 포인트가 없으면 해당 플레이어는 건너뜁니다.
+            }
+
+            // PlayerController 프리팹을 인스턴스화합니다.
+            GameObject go = PhotonNetwork.Instantiate(Path.Combine("Prefabs", "PlayerConrtoller"), playerSpawnPos.position, Quaternion.identity);
+            GamePlayer gamePlayer = go.GetComponent<GamePlayer>();
+
+            if (gamePlayer == null)
+            {
+                Debug.LogError("인스턴스화된 PlayerController에서 GamePlayer 컴포넌트를 찾을 수 없습니다!");
+                PhotonNetwork.Destroy(go); // 정리
+                continue;
+            }
+
+            string uid = photonPlayer.CustomProperties["uid"]?.ToString();
+            PlayerData pd = PlayerManager.Instance?.GetFindPlayerDataFromID(uid);
+
+            if (pd != null)
+            {
+                gamePlayer._data = pd;
+            }
+            else
+            {*/
+    // PlayerManager가 없거나 데이터가 없는 경우를 위한 폴백
+    /*if (photonPlayer.IsLocal)
+    {
+        // 로컬 플레이어인 경우, 이 매니저에 저장된 로컬 플레이어 데이터를 사용합니다.
+        gamePlayer._data = _playerData;
+    }
+    else
+    {
+        // PlayerManager가 데이터를 제공하지 못하면 기본 데이터를 생성합니다.
+        gamePlayer._data = new PlayerData(photonPlayer.NickName, uid, 0, 0);
+        Debug.LogWarning($"{photonPlayer.NickName}에 대한 PlayerData를 찾을 수 없습니다. 기본 데이터를 사용합니다.");
+    }*/
+    /*}
+    gamePlayer._spawnPointindex = playerSpawnIndex;
+
+    // 생성된 객체의 소유권을 실제 플레이어에게 이전합니다.
+    PhotonView photonView = go.GetComponent<PhotonView>();
+    if (photonView != null && photonView.Owner != photonPlayer)
+    {
+        photonView.TransferOwnership(photonPlayer);
+        Debug.Log($"{go.name}의 소유권을 {photonPlayer.NickName}에게 이전했습니다.");
+    }
+    else if (photonView == null)
+    {
+        Debug.LogError("PlayerController에서 PhotonView를 찾을 수 없습니다!");
+    }
+
+    gamePlayer.SendMyPlayerDataRPC();
+}
+}*/
+
+    #endregion
 
     //TODO - 리펙토링의 필요 - 다인전 할 때 생성 순서를 정해줘서 생성해야한다.
     //<Before : 마스터 클라이언트 먼저 생성, After : 나머지 사람 생성> 구조 
-    private void CreateController()
+    public void CreateController()
     {
         if (!PhotonNetwork.IsMasterClient)
         {
@@ -39,9 +138,7 @@ public class InGamePlayerManager : MonoBehaviourPunCallbacks
 
         if (PhotonNetwork.IsMasterClient)
         {
-            Transform playerSpawnPos;
-            int playerSpawnIndex;
-            (playerSpawnPos, playerSpawnIndex) = SpawnManager.Instance.GetAndClaimRandomSpawnPoint();
+            (Transform playerSpawnPos, int playerSpawnIndex) = SpawnManager.Instance.GetAndClaimRandomSpawnPoint();
 
             if (playerSpawnPos == null)
             {
@@ -62,11 +159,9 @@ public class InGamePlayerManager : MonoBehaviourPunCallbacks
     private IEnumerator HeyWait()
     {
         Debug.Log("잠시멈춤");
-        yield return new WaitForSeconds(5.0f);
+        yield return new WaitForSeconds(1.0f);
 
-        Transform playerSpawnPos;
-        int playerSpawnIndex;
-        (playerSpawnPos, playerSpawnIndex) = SpawnManager.Instance.GetAndClaimRandomSpawnPoint();
+        (Transform playerSpawnPos, int playerSpawnIndex) = SpawnManager.Instance.GetAndClaimRandomSpawnPoint();
 
         if (playerSpawnPos == null)
         {

--- a/Assets/PMS/PMS_Scripts/PlayerManager.cs
+++ b/Assets/PMS/PMS_Scripts/PlayerManager.cs
@@ -73,6 +73,12 @@ public class PlayerManager : Singleton<PlayerManager>
 
     public void RegisterPlayer(GamePlayer player)
     {
+        if (string.IsNullOrEmpty(player.PlayerId))
+        {
+            Debug.LogError("null값 등록시도.");
+            return;
+        }
+
         if (!_players.ContainsKey(player.PlayerId))
         {
             _players.Add(player.PlayerId, player);

--- a/Assets/PMS/PMS_Scripts/SpawnManager.cs
+++ b/Assets/PMS/PMS_Scripts/SpawnManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -13,6 +14,7 @@ public class SpawnManager : MonoBehaviourPunCallbacks
 
     private Transform[] _allSpawnPoints;
 
+
     //여기까지는 모든 유저가 해도됨.
     private void Awake()
     {
@@ -23,6 +25,7 @@ public class SpawnManager : MonoBehaviourPunCallbacks
             return;
         }
         Instance = this;
+
 
         // 만약 Inspector에서 설정하지 않았다면, 여기에서 자식 Transform들을 스폰 포인트로 초기화
         if (_allSpawnPoints == null || _allSpawnPoints.Length == 0)
@@ -36,6 +39,16 @@ public class SpawnManager : MonoBehaviourPunCallbacks
             }
             _allSpawnPoints = children.ToArray();
             Debug.Log($"SpawnManager : {_allSpawnPoints.Length}개의 스폰포인트를 찾았습니다.");
+        }
+
+        if (PhotonNetwork.IsMasterClient)
+        {
+            Debug.Log("스폰 초기화");
+            InitializeAvailableSpawnPoints(); //마스터클라이언트만 룸 프로퍼티 스폰 초기화 
+        }
+        else
+        {
+            StartCoroutine(InitDelay());
         }
     }
 
@@ -162,5 +175,10 @@ public class SpawnManager : MonoBehaviourPunCallbacks
         props.Add(key, true);
         PhotonNetwork.CurrentRoom.SetCustomProperties(props);
         Debug.Log($"SpawnManager: Master Client returned spawn point index {spawnPointIndex}.");
+    }
+
+    private IEnumerator InitDelay()
+    {
+        yield return new WaitForSeconds(0.1f);
     }
 }

--- a/Assets/PMS/PMS_Scripts/TestScirpts/PMS_GameManager.cs
+++ b/Assets/PMS/PMS_Scripts/TestScirpts/PMS_GameManager.cs
@@ -15,7 +15,7 @@ public class PMS_GameManager : MonoBehaviour
             PhotonNetwork.CurrentRoom.CustomProperties.ContainsKey("GameStart") &&
             (bool)PhotonNetwork.CurrentRoom.CustomProperties["GameStart"] == true && !flag)
         { 
-            StartCoroutine(Delay());
+            StartCoroutine(MasterClientSpawnPlayersWithDelay());
             flag = true;  
         }
     }
@@ -26,5 +26,13 @@ public class PMS_GameManager : MonoBehaviour
     {
         yield return new WaitForSeconds(0.1f); 
         //PlayerManager.Instance.AllGamePlayerAdd();
+    }
+
+    //마스터 클라이언트가 Spawn담당 할 때
+    private IEnumerator MasterClientSpawnPlayersWithDelay()
+    {
+        yield return new WaitForSeconds(0.1f); // 씬 로딩 및 초기화가 완료될 시간을 주기 위한 약간의 지연
+        //InGamePlayerManager.Instance.MasterClientSpawnAllPlayers(); // 새로운 메서드 호출
+        InGamePlayerManager.Instance.CreateController();
     }
 }

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -57,6 +57,11 @@ MonoBehaviour:
   - RPC_UpdatePlayerCurrentHp
   - RPC_UpdatePlayerMaxHp
   - RPC_DecreasePlayerHp
+  - ReloadSync
+  - RequestEndTurn
+  - RPC_SwitchNextBullet
+  - SyncTurn
+  - RPC_RegisterAllPlayer
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1


### PR DESCRIPTION
## 🔥 작업 내용 요약
- 어떤 기능을 구현했는지 간단히 설명 (셋 중에 하나 골라서 작성)
- Feature :
  - 기능 요약 : 마스터 클라이언트 Scene이동 추가
  - 구현 내용 : PhotonNetwork.AutomaticallySyncScene = true; 설정해야 다른 클라이언트들도 씬을 로드함
  - 테스트 코드로 게임 강제 시작 코루틴에 PhotonNetwork.LoadLevel("PMS_TestScene");추가하여 테스트 진행
  - 모든 클라이언트가 다음 씬으로 잘 넘어감
- Bugfix :
  - 버그 내용 : 플레이어 ID 전달 문제 - PlayerSpawn이 InGamePlayerManager를 통해 이루어져야 하는데 그렇지 못해서 ID값을 전달받지 못함.
  - 해결 방안 : InGamePlayerManager를 싱글톤으로 둠 - 해당 매니저 생성시기가 Room에 들어왔을 때라 일단 급한대로 싱글톤으로 만들어서 그냥 파괴되지 않게 일단 조치함.
- Refactor :
  - 작업 내용 : 플레이어 프로퍼티 사용으로 playerid를 uid 설정할 수 있게 테스트 해봄
  - 리펙토링 의도 : 추후 uid를 받을 때 플레이어 프로퍼티로 등록하면 자동으로 마스터클라이언트 업데이트 된 플레이어 프로퍼티를 확인하여 해당 유저의 PlayerData를 PlayerManager스크립트의 PlayerData List에 추가 

## 🧪 테스트 방법
- 유니티 패럴싱크

## 🤝 관련 이슈

## ✅ 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항

