### PR TITLE
NetworkManager, RoomManager 리팩토링, 주석 추가 / 버그 픽스

### DIFF
--- a/Assets/LHJ/LHJ_Scripts/NetworkManager.cs
+++ b/Assets/LHJ/LHJ_Scripts/NetworkManager.cs
@@ -64,6 +64,8 @@ public class NetworkManager : MonoBehaviourPunCallbacks
     
     private void Init()
     {
+        PhotonNetwork.AutomaticallySyncScene = true; 
+        
         _uiNicknamePanel = nicknamePanel.GetComponent<UI_Nickname>();
         _uiLobby = lobbyPanel.GetComponent<UI_Lobby>();
         

--- a/Assets/LHJ/LHJ_Scripts/NetworkManager.cs
+++ b/Assets/LHJ/LHJ_Scripts/NetworkManager.cs
@@ -13,8 +13,12 @@ using System.Linq;
 using Utils;
 using static Utils.Define_LDH;
 
+/// <summary>
+/// Photon 네트워크 연결 및 유저 UI 흐름 전체를 제어하는 매니저
+/// </summary>
 public class NetworkManager : MonoBehaviourPunCallbacks
 {
+    #region UI 연결 필드
     [Header("Loading")]
     [SerializeField] private GameObject loadingPanel;
     
@@ -34,22 +38,26 @@ public class NetworkManager : MonoBehaviourPunCallbacks
     [SerializeField] private Transform roomListContent;
     [SerializeField] private TMP_InputField codeInputField;
     [SerializeField] private Button codeJoinButton;
-
-
     
     [Header("Room")]
     [SerializeField] private GameObject roomPanel;
     [SerializeField] private RoomManager roomManager;
-    private Dictionary<string, GameObject> roomList = new Dictionary<string, GameObject>();
-    public IReadOnlyList<GameObject> RoomList => roomList.Values.ToList();
+
+    #endregion
     
-    
-    #region ui scripts reference (private 접근자)
+    #region UI 스크립트 참조 캐싱
     private UI_Nickname _uiNicknamePanel;
     private UI_Lobby _uiLobby;
     private ModalWindowManager _createRoomManager;
     #endregion
 
+    /// <summary>
+    /// 로비에서 보여지는 방 리스트 캐싱 (Key: roomName)
+    /// </summary>
+    private Dictionary<string, GameObject> roomList = new Dictionary<string, GameObject>();
+    public IReadOnlyList<GameObject> RoomList => roomList.Values.ToList();
+
+    
     private void Awake() => Init();
     
     void Start()
@@ -60,39 +68,41 @@ public class NetworkManager : MonoBehaviourPunCallbacks
         codeJoinButton.onClick.AddListener(JoinRoomByCode);
     }
 
-    #region Init
+    #region Init 초기화
     
     private void Init()
     {
         PhotonNetwork.AutomaticallySyncScene = true; 
         
+        // 연결된 UI 스크립트 참조
         _uiNicknamePanel = nicknamePanel.GetComponent<UI_Nickname>();
         _uiLobby = lobbyPanel.GetComponent<UI_Lobby>();
         
         InitUIVisibiity();
     }
 
+    /// <summary>
+    /// 모든 UI 비활성화 및 초기 상태 세팅
+    /// </summary>
     private void InitUIVisibiity()
     {
-        //loading 활성화
-        loadingPanel.SetActive(true);
-        //lobby 비활성화
-        lobbyPanel.SetActive(false);
-        //user label 비활성화
-        userLabel.SetActive(false);
-        //nickname 설정 패널 invisible
-        _uiNicknamePanel.SetActive(false);
-        //create room 패널 invisible
-        _uiLobby.CreateRoomPanel.CloseWindow();
-        //join room by code 패널 invisible
-        _uiLobby.JoinRoomPanel.CloseWindow();
-        //room 비활성화
-        roomPanel.SetActive(false);
+        loadingPanel.SetActive(true);               // 로딩 ON
+        lobbyPanel.SetActive(false);                // 로비 UI OFF
+        userLabel.SetActive(false);                 // 유저 라벨 OFF
+        _uiNicknamePanel.SetActive(false);          // 닉네임 창 닫기
+        _uiLobby.CreateRoomPanel.CloseWindow();     // 방 생성 패널 닫기
+        _uiLobby.JoinRoomPanel.CloseWindow();       // 코드 입력 패널 닫기
+        roomPanel.SetActive(false);                 // 방 UI OFF
     }
+    
     #endregion
-
-    #region Connect
-    // 마스터 서버 연결
+    
+    #region Connect PunCallbacks
+    /// <summary>
+    /// 마스터 서버 연결 완료 시 처리
+    /// - 첫 접속이면 닉네임 입력창 활성화
+    /// - 재접속이면 자동으로 로비 진입
+    /// </summary>
     public override void OnConnectedToMaster()
     {
         if (loadingPanel.activeSelf)
@@ -102,13 +112,14 @@ public class NetworkManager : MonoBehaviourPunCallbacks
         }
         else
         {
-            PhotonNetwork.JoinLobby();  // 로비로 진입
-            roomPanel.SetActive(false);
+            PhotonNetwork.JoinLobby();            // 로비로 진입
+            roomPanel.SetActive(false);           // 룸 panel 비활성화
         }
-        
-        
-
     }
+    
+    /// <summary>
+    /// 서버 연결 끊어졌을 때 재접속 시도
+    /// </summary>
     public override void OnDisconnected(DisconnectCause cause)
     {
         base.OnDisconnected(cause);
@@ -118,49 +129,55 @@ public class NetworkManager : MonoBehaviourPunCallbacks
 
     #endregion
     
-    
     #region NickName
 
-    // 닉네임 설정 및 로비진입
+    /// <summary>
+    /// 유저 닉네임 설정 후 로비 진입 시도
+    /// </summary>
     public void NicknameAdmit()
     {
-        // 닉네임 이미 설정
+        // 닉네임 이미 설정된 상태
         if (!string.IsNullOrEmpty(PhotonNetwork.NickName))
             return;
         
-        if (string.IsNullOrWhiteSpace(nicknameField.text))
+        string nickname = nicknameField.text.Trim();
+        if (string.IsNullOrWhiteSpace(nickname))
         {
             Manager.UI.ShowNotifyModal(NotifyMessage.MessageEntities[NotifyMessageType.NicknameError]);     // ui modal
             return;
         }
         
-        PhotonNetwork.NickName = nicknameField.text.Trim();
-        
+        PhotonNetwork.NickName = nickname;
         Manager.UI.ShowNotifyModal(NotifyMessage.MessageEntities[NotifyMessageType.NicknameSuccess]);       // ui modal
         
-        PhotonNetwork.JoinLobby();
+        PhotonNetwork.JoinLobby();     // 로비 진입
         
     }
 
     #endregion
-
-    #region Lobby PunCallbacks
+    
+    #region Lobby PunCallbacks (로비 연결 콜백)
 
     public override void OnJoinedLobby()
     {
         base.OnJoinedLobby();
-        _uiNicknamePanel.SetActive(false);          // close window
-        lobbyPanel.SetActive(true);
-        userLabel.SetActive(true);                  // activate user label canvas
         
-        //shortcut 활성화
+        _uiNicknamePanel.SetActive(false);    // 닉네임 설정창 닫기
+        lobbyPanel.SetActive(true);           // 로비 UI 활성화
+        userLabel.SetActive(true);            // 유저 정보 라벨 활성화
+        
+        // 글로벌 단축키 UI 세팅
         UI_Shortcut shortcutUI = Manager.UI.GetGlobalUI(GlobalUI.UI_Shortcut) as UI_Shortcut;
-        if (shortcutUI.gameObject.activeSelf) return;
-        shortcutUI.InitSetting();
-        shortcutUI.Show();
+        if (!shortcutUI.gameObject.activeSelf)
+        {
+            shortcutUI.InitSetting();
+            shortcutUI.Show();
+        }
     }
 
-    // 방 리스트 갱신
+    /// <summary>
+    /// 로비 내 방 리스트 갱신 콜백
+    /// </summary>
     public override void OnRoomListUpdate(List<RoomInfo> updateList)
     {
         foreach (RoomInfo info in updateList)
@@ -178,11 +195,12 @@ public class NetworkManager : MonoBehaviourPunCallbacks
 
             if (roomList.ContainsKey(info.Name))
             {
-                // 방 정보 업데이트
+                // 방 정보 업데이트 (기존 방 정보 갱신)
                 roomList[info.Name].GetComponent<RoomList>().Init(info, _uiLobby);
             }
             else
             {
+                // 새로운 방 추가
                 GameObject roomListItem = Instantiate(roomListPrefabs);
                 roomListItem.transform.SetParent(roomListContent, false);
                 roomListItem.GetComponent<RoomList>().Init(info, _uiLobby);
@@ -191,11 +209,13 @@ public class NetworkManager : MonoBehaviourPunCallbacks
         }
     }
     #endregion
+    
+    #region Create Room Logic (방 생성 처리)
 
-  
-    #region Create Room Logic
-
-    // 방 생성
+    
+    /// <summary>
+    /// UI에서 방 생성 요청 시 호출
+    /// </summary>
     public void CreateRoom()
     {
         string userRoomName = roomNameField.text;
@@ -207,14 +227,15 @@ public class NetworkManager : MonoBehaviourPunCallbacks
         
         roomNameAdmitButton.interactable = false;
         
-        // 1. 고유 코드 생성 (중복 검사 포함)
+        // 1. 고유 코드 생성 (GUID 기반 고유 roomName, roomCode 생성)
         var (roomCode, roomName) = GenerateRoomCode();
         if (string.IsNullOrEmpty(roomCode) || string.IsNullOrEmpty(roomName))
         {
-            Debug.LogError("방 코드 생성 실패. 방 생성 중단.");
+            Debug.LogError("[Create Room] 방 코드 생성 실패. 방 생성 중단.");
             return;
         }
         
+        // 2. 방에 포함될 커스텀 속성 정의
         ExitGames.Client.Photon.Hashtable customProperties = new ExitGames.Client.Photon.Hashtable
         {
             { "roomCode", roomCode },
@@ -228,17 +249,22 @@ public class NetworkManager : MonoBehaviourPunCallbacks
             CustomRoomPropertiesForLobby = new[] { "roomCode", "userRoomName" }
         };
         
+        // 3. 방 생성 및 속성 적용
         PhotonNetwork.CreateRoom(roomName, options);
         
+        // 4. 모달 알림 팝업
         Manager.UI.ShowNotifyModal(NotifyMessage.MessageEntities[NotifyMessageType.CreeateRoomSuccess]);
         
-        //패널 닫기
+        // 5. panel 닫기 (close window)
         _uiLobby.CreateRoomPanel.CloseWindow();
         
+        // 6. inputfield 초기화
         roomNameField.text = null;
     }
 
-    //GUID 앞부분만 잘라서 고유 코드로 생성
+    /// <summary>
+    /// 고유한 방 코드와 GUID RoomName 생성
+    /// </summary>
     private (string roomCode, string guidRoomName) GenerateRoomCode(int length = 6, int retryCount = 0)
     {
         
@@ -259,13 +285,16 @@ public class NetworkManager : MonoBehaviourPunCallbacks
         if (CheckRoomCodeDuplicate(roomCode))
         {
             Debug.LogWarning($"[GenerateRoomCode] 중복 코드: {roomCode}, 재시도...");
-            GenerateRoomCode(length, retryCount + 1);
+            GenerateRoomCode(length, retryCount + 1);       // 재귀 호출
         }
 
         return (roomCode, roomName); // roomName = guid
 
     }
     
+    /// <summary>
+    /// 현재 방 리스트에 중복 roomCode가 있는지 확인
+    /// </summary>
     private bool CheckRoomCodeDuplicate(string code)
     {
         return roomList.Values.Any(go =>
@@ -278,101 +307,123 @@ public class NetworkManager : MonoBehaviourPunCallbacks
 
     #endregion
 
-    #region Join Room By Code
+    #region Join Room By Code (방 코드로 방 입장)
 
+    /// <summary>
+    /// 코드 입력을 통해 특정 방에 입장 시도
+    /// </summary>
     public void JoinRoomByCode()
     {
         string roomCode = codeInputField.text.Trim().ToUpper();
+        
+        //빈 문자열 입력
         if (string.IsNullOrEmpty(roomCode))
         {
             Manager.UI.ShowNotifyModal(NotifyMessage.MessageEntities[NotifyMessageType.RoomCodeEmpty]);
             return;
         }
 
+        // 1. roomCode 기준으로 매칭되는 RoomList 객체 탐색
         RoomList matchedRoom = roomList.Values
             .Select(go => go.GetComponent<RoomList>())
             .FirstOrDefault(room => room.RoomCode == roomCode);
         
+        // 2. 일치하는 방이 없는 경우
         if (matchedRoom == null)
         {
             Manager.UI.ShowNotifyModal(NotifyMessage.MessageEntities[NotifyMessageType.RoomCodeError]);
             return;
         }
         
-        // 플레이어 수 초과 체크
+        // 3. 일치하는 방이 있는 경우 -> 플레이어 수 초과 체크
         if (matchedRoom.RoomInfo.PlayerCount >= matchedRoom.RoomInfo.MaxPlayers)
         {
             Manager.UI.ShowNotifyModal(NotifyMessage.MessageEntities[NotifyMessageType.JoinRoomError]);
             return;
         }
         
+        // 4. 모든 조건 만족하는 경우 진입처리
         if (PhotonNetwork.InLobby)
         {
-            Manager.UI.ShowNotifyModal(NotifyMessage.MessageEntities[NotifyMessageType.RoomCodeSuccess]);
+            Manager.UI.ShowNotifyModal(NotifyMessage.MessageEntities[NotifyMessageType.RoomCodeSuccess]);       // 모달 팝업
             
-            PhotonNetwork.JoinRoom(matchedRoom.RoomName);
+            PhotonNetwork.JoinRoom(matchedRoom.RoomName);               // 방 입장
             
-            _uiLobby.JoinRoomPanel.CloseWindow();
-        
-            codeInputField.text = null;
+            _uiLobby.JoinRoomPanel.CloseWindow();                       // 패널 비활성화
+            
+            codeInputField.text = null;                                 // inputfield 초기화
           
         }
-        
-        
         codeJoinButton.interactable = false;
-
     }
-   
-
+    
     #endregion
 
     #region Room PunCallbacks
 
-    // 방 생성 완료
+    /// <summary>
+    /// 방 생성 성공 시 호출됨
+    /// </summary>
     public override void OnCreatedRoom()
     {
-        roomNameAdmitButton.interactable = true; // 버튼 활성화
+        roomNameAdmitButton.interactable = true;    // 버튼 복원 (방 생성 시 비활성화 시킨 버튼 복원)
     }
     
-    // 방 입장 완료시 
+    
+    // /// <summary>
+    // /// 방 입장 성공 시 UI 상태 초기화 및 플레이어 패널 생성
+    // /// </summary>
     public override void OnJoinedRoom()
     {
+        
         lobbyPanel.SetActive(false);
         roomPanel.SetActive(true);
-        roomManager.InitRoom();
+
+        codeJoinButton.interactable = true;         // 버튼 복원 (코드로 방 입장 시 비활성화 시켰던 버튼 복원)
+        
+        roomManager.InitRoom();                     // UI 및 설정 초기화
         foreach (Player player in PhotonNetwork.PlayerList)
         {
-            roomManager.SetPlayerPanel(player);
+            roomManager.SetPlayerPanel(player);     // 각 플레이어 UI 설정
         }
     }
     
     
-    // 다른 플레이어가 방에 입장했을때 
+    /// <summary>
+    /// 다른 플레이어가 방에 새로 입장했을 때 호출
+    /// </summary>
     public override void OnPlayerEnteredRoom(Player newPlayer)
     {
         if (newPlayer != PhotonNetwork.LocalPlayer)
-            roomManager.SetPlayerPanel(newPlayer);
+            roomManager.SetPlayerPanel(newPlayer);      // 들어온 플레이어의 UI 설정
     }
     
     
-    // 다른 플레이어가 방에서 나갔을때 
+    /// <summary>
+    /// 다른 플레이어가 방에서 나갔을 때 호출
+    /// </summary>
     public override void OnPlayerLeftRoom(Player otherPlayer)
     {
         if (otherPlayer != PhotonNetwork.LocalPlayer)
-            roomManager.ResetPlayerPanel(otherPlayer);
+            roomManager.ResetPlayerPanel(otherPlayer);  // 나간 플레이어의 UI 초기화
     }
     
     
-
+    /// <summary>
+    /// 방장이 바뀌었을 때 호출됨 (기존 HOST 퇴장)
+    /// </summary>
     public override void OnMasterClientSwitched(Player newMasterClient)
     {
-        if (newMasterClient.IsLocal)
+        if (newMasterClient.IsLocal) // 바뀐 마스터 플레이어가 로컬인 쪽에서만 UI 갱신 및 설정 초기화
         {
             roomManager.SwitchMasterClient(newMasterClient);
         }
      
     }
     
+    /// <summary>
+    /// 플레이어의 Custom Property (Ready 등) 변경 시 호출됨
+    /// </summary>
     public override void OnPlayerPropertiesUpdate(Player targetPlayer, Hashtable changedProps)
     {
         if (changedProps.ContainsKey("Ready"))

--- a/Assets/LHJ/LHJ_Scripts/RoomList.cs
+++ b/Assets/LHJ/LHJ_Scripts/RoomList.cs
@@ -49,7 +49,6 @@ public class RoomList : MonoBehaviour
     /// <param name="lobby">소속 로비 UI</param>
     public void Init(RoomInfo info, UI_Lobby lobby)
     {
-        Debug.Log("roomlist init 호출 시점");
         //------ data 초기화 -----//
         _info = info;
         _lobby = lobby;

--- a/Assets/LHJ/LHJ_Scripts/RoomManager.cs
+++ b/Assets/LHJ/LHJ_Scripts/RoomManager.cs
@@ -5,6 +5,12 @@ using Photon.Realtime;
 using System;
 using UnityEngine;
 
+/// <summary>
+/// 방 내부의 플레이어 패널 관리 및 게임 시작/퇴장 로직을 담당하는 매니저
+/// - 방장/클라이언트의 역할 분기
+/// - 플레이어 입/퇴장 시 UI 반영
+/// - Ready 상태 기반 게임 시작 가능 여부 판단
+/// </summary>
 public class RoomManager : MonoBehaviour
 {
     //UI와 컨트롤 로직을 분리 -> 필요없는 변수 제거
@@ -12,73 +18,122 @@ public class RoomManager : MonoBehaviour
     [SerializeField] private UI_Room _uiRoom;
     [SerializeField] private string gameSceneName;
 
+    
     private void OnDestroy()
     {
+        // 이벤트 등록 해제 (메모리 누수 방지)
         _uiRoom.OnClickStartButton -= GameStart;
         _uiRoom.OnClickLeaveButton -= LeaveRoom;
     }
-    
 
-    // 개별 플레이어 패널 생성
-    public void SetPlayerPanel(Player player)
-    {
-       // PhotonNetwork.AutomaticallySyncScene = true;
-        _uiRoom.SetPlayerPanel(player);
-    }
 
+    #region 초기화
+
+    /// <summary>
+    /// 방에 진입했을 때 UI 초기화
+    /// - 방장인 경우 Start 버튼에 GameStart 기능 부여
+    /// </summary>
     public void InitRoom()
     {
         if(PhotonNetwork.LocalPlayer.IsMasterClient)
-            _uiRoom.Init(GameStart, LeaveRoom);
+            _uiRoom.Init(GameStart, LeaveRoom);      // 방장용 UI
         else
-            _uiRoom.Init(null, LeaveRoom);
+            _uiRoom.Init(null, LeaveRoom);    // 일반 유저용 UI
     }
 
-    // 방장 및 모든 플레이어가 준비완료시 시작
+    #endregion
+    
+    
+    #region 게임 시작 / 퇴장
+
+    /// <summary>
+    /// 게임 시작 로직
+    /// - 방장만 호출 가능
+    /// - 준비 완료 여부는 버튼 활성화 조건에서 이미 확인됨
+    /// </summary>
     public void GameStart()
     {
-        // if (PhotonNetwork.IsMasterClient && AllPlayerReadyCheck()) // -> 마스터 클라이언트에게만 Game Start 기능 부여 & 버튼 활성화에서 Ready Check를 진행하는 로직으로 변경함에 따라 주석 처리
+        // if (PhotonNetwork.IsMasterClient && AllPlayerReadyCheck()) 
+        // -> 마스터 클라이언트에게만 Game Start 기능 부여 & 버튼 활성화에서 Ready Check를 진행하는 로직으로 변경함에 따라 주석 처리
+        
         PhotonNetwork.LoadLevel(gameSceneName);
     }
     
+    /// <summary>
+    /// 방 나가기 로직
+    /// - 본인 UI 초기화
+    /// - Ready 상태 false로 리셋
+    /// </summary>
     public void LeaveRoom()
     {
-        // foreach (var player in PhotonNetwork.PlayerList)
-        // {
-        //     _uiRoom.ResetPanel(player);
-        // }
+        // 자신의 UI만 초기화
         ResetPlayerPanel(PhotonNetwork.LocalPlayer);
+        
+        // 자신의 custom property 초기화
         Hashtable playerProperty = new Hashtable
         {
             { "Ready", false }
         };
+        
         PhotonNetwork.LocalPlayer.SetCustomProperties(playerProperty);
         
         PhotonNetwork.LeaveRoom(); // 방 나가기
     }
+
+    #endregion
+
+    #region Mastaer Client 전환
+
+    /// <summary>
+    /// 방장이 변경되었을 때 호출됨
+    /// - 새로운 방장이 된 클라이언트는 UI 및 Start 버튼 상태 재설정
+    /// </summary>
+    public void SwitchMasterClient(Player newMaster)
+    {
+        InitRoom();  // 새 방장의 권한에 맞게 UI 버튼 구성
+        foreach (Player player in PhotonNetwork.PlayerList)
+        {
+            SetPlayerPanel(player);  // 모든 플레이어 UI 다시 갱신
+        }
+    }
+
+    #endregion
     
-    // 나간 플레이어의 패널 제거
+  
+    #region UI
+
+    /// <summary>
+    /// 로컬/외부 플레이어 입장 시 UI 패널 생성
+    /// </summary>
+    public void SetPlayerPanel(Player player)
+    {
+        // PhotonNetwork.AutomaticallySyncScene = true;
+        _uiRoom.SetPlayerPanel(player);
+    }
+
+    /// <summary>
+    /// 특정 플레이어의 UI 패널 제거 (퇴장 시 호출)
+    /// </summary>
     public void ResetPlayerPanel(Player player)
     {
         _uiRoom.ResetPanel(player);
     }
 
-    public void SwitchMasterClient(Player newMaster)
-    {
-        InitRoom();
-        foreach (Player player in PhotonNetwork.PlayerList)
-        {
-            SetPlayerPanel(player);
-        }
-    }
-    
+    /// <summary>
+    /// 특정 플레이어의 Ready 상태 변경 시 호출됨
+    /// - Ready UI 업데이트
+    /// - Start 버튼 조건도 재평가
+    /// </summary>
     public void UpdateReadyUI(Player player)
     {
         _uiRoom.UpdateReadyUI(player);
         _uiRoom.UpdateStartButtonState(AllPlayerReadyCheck());
     }
-    
 
+    /// <summary>
+    /// 현재 방의 모든 플레이어가 Ready 상태인지 확인
+    /// - 게임 시작 조건 판단용
+    /// </summary>
     // 모든플레이어가 준비완료 상태인지
     public bool AllPlayerReadyCheck()
     {
@@ -92,6 +147,7 @@ public class RoomManager : MonoBehaviour
         return true;
     }
 
+    #endregion
    
  
 }


### PR DESCRIPTION
## 🔥 작업 내용 요약

- Bugfix :
  - 버그 내용 : 기존 코드가 주석 처리되어 게임 시작 시 씬 동기화가 되지 않음
  - 해결 방안 : PhotonNetwork.AutomaticallySyncScene 설정을 복구 -> NetworkManager 의 Init로 이동

  - 버그 내용 : 방 코드로 방 입장 후 join room by code panel의 버튼 비활성화 복구가 되지 않음
  - 해결 방안 : 방 진입 시 복구 되도록 콜백 함수에 복구 코드 추가

- Refactor :
  - 작업 내용 : NetworkManager, RoomManager 주석 추가
  - 리펙토링 의도 : 가독성 향상을 위해 region으로 구분, 코드 변동이 많았기 때문에 이해를 돕기 위해 주석 추가

## 🧪 테스트 방법
x

## 🤝 관련 이슈
x

## ✅ 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항

