### PR TITLE
[Fix] Merge 처리 중 생긴 SetPlayerPanel() 중복 정의 오류 수정

### DIFF
--- a/Assets/LHJ/LHJ_Scripts/RoomManager.cs
+++ b/Assets/LHJ/LHJ_Scripts/RoomManager.cs
@@ -25,13 +25,7 @@ public class RoomManager : MonoBehaviour
         _uiRoom.OnClickStartButton -= GameStart;
         _uiRoom.OnClickLeaveButton -= LeaveRoom;
     }
-
-    // 개별 플레이어 패널 생성
-    public void SetPlayerPanel(Player player)
-    {
-        // PhotonNetwork.AutomaticallySyncScene = true;
-        _uiRoom.SetPlayerPanel(player);
-    }
+    
 
     #region 초기화
 


### PR DESCRIPTION
## 🔥 작업 내용 요약
- Bugfix :
   - 버그 내용 : SetPlayerPanel() 메서드가 두 번 정의되어 중복 오류가 발생했습니다.
   - 해결 방안 : 어제 Merge 과정에서 SetPlayerPanel() 관련 충돌이 있었고, 해당 메서드를 수정하며 위치를 변경했는데 충돌을 해결할 때 이를 인지하지 못한 채, 기존 메서드를 남겨두는 바람에 동일한 이름의 메서드가 두 번 정의된 상태가 되었습니다.
이로 인해 다른 스크립트에서 player 관련 로직 수행 중 오류가 발생하여, 중복 정의된 메서드 중 하나를 제거하여 문제를 해결했습니다.

## 🧪 테스트 방법

## 🤝 관련 이슈

## ✅ 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항


