### PR TITLE
[Fix] 플레이어 hp 동기화 및 버그 Fix

### DIFF
--- a/Assets/PMS/PMS_Scripts/GamePlayer.cs
+++ b/Assets/PMS/PMS_Scripts/GamePlayer.cs
@@ -5,14 +5,14 @@ using UnityEngine;
 using Photon.Pun;
 using Photon.Realtime;
 
-public class GamePlayer : MonoBehaviour, IComparer<GamePlayer>
+public class GamePlayer : MonoBehaviourPun, IComparer<GamePlayer>
 {
     public PhotonView _pv;
 
     public PlayerData _data;
 
     //데이터를 읽기는 해야하는데 Write하면 안되는 데이터
-    public string Nickname => _data.nickname;       
+    public string Nickname => _data.nickname;
     public string PlayerId => _data.playerId;
 
     //읽고 써야 하는 데이터
@@ -50,7 +50,7 @@ public class GamePlayer : MonoBehaviour, IComparer<GamePlayer>
                 _currentHp = value;
                 if (CurrentHp <= 0) IsAlive = false;
 
-                OnHpChanged?.Invoke(_currentHp,IsAlive);
+                OnHpChanged?.Invoke(_currentHp, IsAlive);
             }
         }
     }
@@ -72,8 +72,8 @@ public class GamePlayer : MonoBehaviour, IComparer<GamePlayer>
     }
 
     //이벤트 
-    public event Action<int,bool> OnHpChanged;           //최대 체력 변경시 - 라운드가 종료 되었을 때
-    public event Action<int,bool> OnMaxHpChanged;         //현재 체력 변경시 - 총을 맞거나 피를 회복할때
+    public event Action<int, bool> OnHpChanged;           //최대 체력 변경시 - 라운드가 종료 되었을 때
+    public event Action<int, bool> OnMaxHpChanged;         //현재 체력 변경시 - 총을 맞거나 피를 회복할때
 
     public event Action<GamePlayer> OnPlayerDied;   // 사망한 플레이어 객체 전달 - 턴관리 넘겨야하는데
 
@@ -82,14 +82,39 @@ public class GamePlayer : MonoBehaviour, IComparer<GamePlayer>
     private void Awake()
     {
         _pv = GetComponent<PhotonView>();
+        Initialize();
     }
 
     private void Start()
     {
+        //StartCoroutine(PlayerListSortDelay());
+    }
+
+    private void Update()
+    {
         if (_pv.IsMine)
         {
-            Initialize();
-            StartCoroutine(PlayerListSortDelay());
+            Debug.Log(PlayerManager.Instance.GetAllPlayers().Count);
+
+            if (Input.GetKeyDown(KeyCode.Tab) && PlayerManager.Instance.GetAllPlayers().Count == 2)
+            {
+                foreach (var a in PlayerManager.Instance.GetAllPlayers())
+                {
+                    Debug.Log($"[GamePlayer]Update에서 호출 - {a.Value.PlayerId}, {a.Value.Nickname},{a.Value.CurrentHp}");
+                }
+            }
+        }
+
+        if (Input.GetKeyDown(KeyCode.C) && PhotonNetwork.IsMasterClient && _pv.IsMine)
+        {
+            IncreaseHp(1);
+            //CurrentHp += 1;
+        }
+
+        if (Input.GetKeyDown(KeyCode.X) && PhotonNetwork.IsMasterClient && _pv.IsMine)
+        {
+            DecreaseHp(1);
+            //CurrentHp -= 1;
         }
     }
 
@@ -111,9 +136,9 @@ public class GamePlayer : MonoBehaviour, IComparer<GamePlayer>
         }
     }*/
 
+    //프로퍼티 사용해서 이벤트 호출하게 해야함 - UI를 위해서
     public void Initialize()
     {
-        //프로퍼티 사용해서 이벤트 호출하게 하여야함. 임시 테스트 코드
         MaxHp = 3;
         CurrentHp = MaxHp;
         IsAlive = true;
@@ -130,37 +155,21 @@ public class GamePlayer : MonoBehaviour, IComparer<GamePlayer>
     }
 
     #region 플레이어 hp 관련 메서드
-
-    [PunRPC]
-    public void RPC_IncreaseHp(int amount)
-    {
-        IncreaseHp(amount);
-    }
-
-
+   
     public void IncreaseHp(int amount)
     {
-        if (!IsAlive) return;
+        //if (!IsAlive) return;
 
-        CurrentHp += amount;
-        CurrentHp = Mathf.Max(CurrentHp, 0); // CurrentHp setter에서 사망 처리
+        _pv.RPC("RPC_InCreasePlayerCurrentHp", RpcTarget.MasterClient, PlayerId, amount);
     }
 
-    public void DecreaseHp(int amount)
+    public void DecreaseHp(int damage)
     {
-        if (!IsAlive) return;
+        //if (!IsAlive) return;
 
-        CurrentHp -= amount;
-        CurrentHp = Mathf.Min(CurrentHp, MaxHp);
-        Debug.Log($"[GamePlayer] {Nickname} → DecreaseHp({amount}) 호출됨, 현재 HP: {CurrentHp}");
+        _pv.RPC("RPC_DecreasePlayerCurrentHp", RpcTarget.MasterClient, PlayerId, damage);
     }
     #endregion
-
-    //Player에서 PlayerData를 넘겨주는 메서드 - 필요하진 모르겟다 
-    public PlayerData ToPlayerData()
-    {
-        return _data;
-    }
 
     #region OnPhotonSerializeView 사용 테스트
     /*public void OnPhotonSerializeView(PhotonStream stream, PhotonMessageInfo info)
@@ -182,6 +191,13 @@ public class GamePlayer : MonoBehaviour, IComparer<GamePlayer>
         }
     }*/
     #endregion
+
+    // 공격 요청 (클라이언트 -> 마스터)
+    public void AttackPlayer(GamePlayer targetPlayer, int damage)
+    {
+        if (!IsAlive || !targetPlayer.IsAlive) return;
+        _pv.RPC("RPC_RequestAttack", RpcTarget.MasterClient, PlayerId, targetPlayer.PlayerId, damage);
+    }
 
     //receiveSpawnPointIndex 범위 0 ~ 플레이어수-1  -> 이값을 가지고 List를 넣는 순서를 제어해도 괜찮을 것 같다. 이유 : 일단 자리에 앉으면 오른쪽으로 도는형식, 1대1에서 의미가 없지만 3인이상일 경우 턴순서를 확인할 수 있다.
     // PlayerData 객체를 직접 전송하는 RPC 함수
@@ -216,5 +232,71 @@ public class GamePlayer : MonoBehaviour, IComparer<GamePlayer>
     {
         yield return new WaitForSeconds(0.1f);
         PlayerManager.Instance._playerList.Sort(Compare);
+    }
+
+    //Player에서 PlayerData를 넘겨주는 메서드 - 필요하진 모르겟다 
+    public PlayerData ToPlayerData()
+    {
+        return _data;
+    }
+
+    //-----------------------동기화 부분 ---------------------------
+    //자기 자신 회복 할 때 마스터 클라이언트한테 요청하는 함수 - 맥주마실 때 자기자신 hp회복을 요청 
+    [PunRPC]
+    public void RPC_InCreasePlayerCurrentHp(string requestId, int healAmount)
+    {
+        if (!PhotonNetwork.IsMasterClient) return;
+
+        var target = PlayerManager.Instance.FindPlayerByUID(requestId);
+        if (target == null) return;
+
+        int newHp = Mathf.Min(target.CurrentHp + healAmount, target.MaxHp);
+        // 결과를 모든 클라에게 전파
+        photonView.RPC("RPC_ApplyHp", RpcTarget.All, requestId, newHp);
+    }
+
+    //자기 자신피가 깎여야하는 걸 마스터 클라이언트 한테 요청
+    [PunRPC]
+    public void RPC_DecreasePlayerCurrentHp(string requestId, int damage)
+    {
+        if (!PhotonNetwork.IsMasterClient) return;
+
+        var target = PlayerManager.Instance.FindPlayerByUID(requestId);
+        if (target == null) return;
+
+        int newHp = Mathf.Max(target.CurrentHp - damage, 0);
+        // 결과를 모든 클라에게 전파
+        photonView.RPC("RPC_ApplyHp", RpcTarget.All, requestId, newHp);
+    }
+
+
+
+    // 공격 요청: 클라이언트에서 마스터에게 요청
+    [PunRPC]
+    void RPC_RequestAttack(string attackerId, string targetId, int damage)
+    {
+        if (!PhotonNetwork.IsMasterClient) return;
+
+        var target = PlayerManager.Instance.FindPlayerByUID(targetId);
+        if (target == null) return;
+
+        int newHp = Mathf.Max(target.CurrentHp - damage, 0);
+        photonView.RPC("RPC_ApplyHp", RpcTarget.All, targetId, newHp);
+    }
+
+
+    /// <summary>
+    /// 모든 클라이언트 한테 요청한 유저의 Id를 찾아 해당 유저의 Id를 마스터가 작업 수행한 것을 전달받아 해당 유저를 hp를 해당값으로 동기화
+    /// </summary>
+    /// <param name="requestId"> 요청한 요정 ID </param>
+    /// <param name="newHp"> 적용시킬 Hp </param>
+
+    [PunRPC]
+    void RPC_ApplyHp(string id, int hp)
+    {
+        var player = PlayerManager.Instance.FindPlayerByUID(id);
+        if (player == null) return;
+
+        player.CurrentHp = hp; //setter 이벤트 호출
     }
 }

--- a/Assets/PMS/PMS_Scripts/PlayerController.cs
+++ b/Assets/PMS/PMS_Scripts/PlayerController.cs
@@ -44,17 +44,6 @@ public class PlayerController : MonoBehaviourPun
         PlayerLook();
     }
 
-    // 해당 함수는 내가 작동시키나 RPC함수의 실행은 모든클라이언트에서 이루어져야함 -> RPCTarget.All로 설정
-    public void AttackPlayer(GamePlayer targetPlayer, int damage)
-    {
-        // 내가 이 공격을 수행하는 주체일 때만 RPC 호출
-        if (photonView.IsMine)
-        {
-            // 타겟 플레이어의 ID를 RPC로 전송하여 모든 클라이언트에서 HP 감소 로직을 실행
-            photonView.RPC("RPC_DecreasePlayerHp", RpcTarget.All, targetPlayer.PlayerId, damage);
-        }
-    }
-
     //시점 변경 테스트코드
     private void PlayerLook()
     {

--- a/Assets/PMS/PMS_Scripts/PlayerNetworkSync.cs
+++ b/Assets/PMS/PMS_Scripts/PlayerNetworkSync.cs
@@ -21,7 +21,7 @@ public class PlayerNetworkSync : MonoBehaviourPun
         }
     }
 
-    private void OnEnable()
+    /*private void OnEnable()
     {
         // GamePlayer의 이벤트를 구독하여 hp 변경시 hp 및 Alive 값 전달 RPC 호출
         if (_gamePlayer != null)
@@ -39,10 +39,10 @@ public class PlayerNetworkSync : MonoBehaviourPun
             _gamePlayer.OnHpChanged -= OnGamePlayerCurrentHpChanged;
             _gamePlayer.OnMaxHpChanged -= OnGamePlayerMaxHpChanged;
         }
-    }
+    }*/
 
     //두개의 이벤트모두 나자신에게 전송할 필요가없다.
-    private void OnGamePlayerMaxHpChanged(int MaxHp, bool isAlive)
+    /*private void OnGamePlayerMaxHpChanged(int MaxHp, bool isAlive)
     {
         // 내가 소유한 GamePlayer의 체력만 동기화
         if (photonView.IsMine)
@@ -122,5 +122,7 @@ public class PlayerNetworkSync : MonoBehaviourPun
         {
             Debug.Log($"[PlayerNetworkSync] {_gamePlayer.Nickname}이 공격하여 {targetPlayer.Nickname}의 HP가 {amount}만큼 감소했습니다. 현재 HP: {targetPlayer.CurrentHp}");
         }
-    }
+    }*/
+
+
 }


### PR DESCRIPTION
## 🔥 작업 내용 요약
- Bugfix :
  - 버그 내용 : 플레이어 hp동기화 작업 UI가 제대로 나오지 않는 현상 
  - 해결 방안 : PlayerHpUI에서 Bind시점을 플레이어가 스폰되서 2명다 PlayerManager에 등록되었을 때 Bind()함수를 호출하여 UI를 등록하게 해주었다.
- Refactor :
  - 작업 내용 : hp를 기존의 개별 동기화에서 마스터 클라이언트 기준으로 체력 감소,증가 로직을 RPC로 요청을 받아 수행하고 그결과를 모든 유저에게 다시 RPC로 전송하는 형식으로 변경 
  - 리펙토링 의도 : 치트방지 및 일괄적으로 모든 유저에게 rpc를 전송을 통해 모든 유저가 같은 정보를 가질 수 있도록 설계
  - 기존의 Decrease를 함수를 쓰고 있는 쪽에 코드를 바꿀 필요없이 내부에서 설계 수정
  - 
## 🧪 테스트 방법
- 유니티 패럴싱크

## 🤝 관련 이슈

## ✅ 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항

