### PR TITLE
[Fix] Manager 수정

### DIFF
--- a/Assets/LDH/LDH_Scripts/Managers/Manager.cs
+++ b/Assets/LDH/LDH_Scripts/Managers/Manager.cs
@@ -72,12 +72,12 @@ namespace Managers
                     
             //각각의 매니저 스크립트를 프리팹에 스크립트를 직접 추가해두거나 아래와 같이 AddComponent로 동적으로 추가한다.
             manager.AddComponent<TestManager>();
-            manager.AddComponent<InGameManager>();
+            //manager.AddComponent<InGameManager>();
             manager.AddComponent<SoundManager>();
-            manager.AddComponent<PlayerManager>();
+            //manager.AddComponent<PlayerManager>();
             manager.AddComponent<UIManager>();
-            manager.AddComponent<GunManager>();
-            manager.AddComponent<ItemSyncManager>();
+            //manager.AddComponent<GunManager>();
+            //manager.AddComponent<ItemSyncManager>();
             manager.AddComponent<CameraManager>();
             manager.AddComponent<AnimationManager>();
         }

--- a/Assets/LHJ/LHJ_Scenes/LHJ_GameScene.unity
+++ b/Assets/LHJ/LHJ_Scenes/LHJ_GameScene.unity
@@ -233,52 +233,6 @@ MonoBehaviour:
   sceneViewId: 2
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!1 &110383533
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 110383535}
-  - component: {fileID: 110383534}
-  m_Layer: 0
-  m_Name: PlayerManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &110383534
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 110383533}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2a7e5ff1c34585842ba9e3a25dac1d38, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _playerList: []
-  _playerDataList: []
---- !u!4 &110383535
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 110383533}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -12.438118, y: -4.2295837, z: 5.8681765}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &133323319
 GameObject:
   m_ObjectHideFlags: 0
@@ -412,6 +366,84 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1001 &247018733
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -9105397608597516240, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: sceneViewId
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: -3092348195253772962, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: sceneViewId
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.0334198
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.677301
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.3411155
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 704364988821564950, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5405539329244583951, guid: 6845f98cfe66db84ab70bf471692ef1d,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6845f98cfe66db84ab70bf471692ef1d, type: 3}
 --- !u!1001 &305842163
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -626,10 +658,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5496e4bfeb75b248bf733c8a59310cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerPrefabName: LTH_Player
+  playerPrefabName: Player
   spawnPoints:
   - {fileID: 1184892834}
   - {fileID: 1254500167}
+  virtualCameras: []
 --- !u!4 &410417250
 Transform:
   m_ObjectHideFlags: 0
@@ -3424,6 +3457,152 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b07caef7e8e26b047820944d888743b8, type: 3}
+--- !u!1001 &3886135626894810174
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1627378647290176247, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_Name
+      value: InGameManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.8880852
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.5914745
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.010602
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3314161308126368331, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5305020070202499777, guid: 0bac792d1f4e66b47bf43b0d7e5a690a,
+        type: 3}
+      propertyPath: sceneViewId
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0bac792d1f4e66b47bf43b0d7e5a690a, type: 3}
+--- !u!1001 &5730016511382371609
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1875941947762760858, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_Name
+      value: GunManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 4545920831931600290, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: sceneViewId
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.8880852
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.5914745
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.010602
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4654570947768147938, guid: 74a0b0b6be4d53444b70583f0b61f0c1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 74a0b0b6be4d53444b70583f0b61f0c1, type: 3}
 --- !u!1001 &7033760018202242175
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3503,10 +3682,12 @@ SceneRoots:
   - {fileID: 626136501}
   - {fileID: 7033760018202242175}
   - {fileID: 981617631589110473}
+  - {fileID: 3886135626894810174}
+  - {fileID: 5730016511382371609}
+  - {fileID: 247018733}
   - {fileID: 447115174}
   - {fileID: 410417250}
   - {fileID: 69467846}
-  - {fileID: 110383535}
   - {fileID: 1995720747}
   - {fileID: 1617094550}
   - {fileID: 240962469}

--- a/Assets/LHJ/LHJ_Scripts/Sync/GameOverSync.cs
+++ b/Assets/LHJ/LHJ_Scripts/Sync/GameOverSync.cs
@@ -11,7 +11,7 @@ public class GameOverSync : MonoBehaviourPunCallbacks
     [SerializeField] private GameObject gameOverPanel;
     [SerializeField] private TextMeshProUGUI winnerText;
     [SerializeField] private TextMeshProUGUI countdownText;
-
+    private PhotonView _pv;
     private bool hasShow = false;
 
     public static GameOverSync Instance;
@@ -78,17 +78,18 @@ public class GameOverSync : MonoBehaviourPunCallbacks
         InGameManager.Release();
         ItemBoxSpawnerManager.Release();
         DeskUIManager.Release();
+        ItemSyncManager.Release();
 
         photonView.RPC("GoToLobbyScene", RpcTarget.All);
     }
     public override void OnLeftRoom()
     {
-        if (Managers.Manager.manager == null)
-        {
-            Debug.LogWarning("@Manager가 없어서 재생성 시도");
+        //if (Managers.Manager.manager == null)
+        //{
+        //    Debug.LogWarning("@Manager가 없어서 재생성 시도");
 
-            Managers.Manager.Initialize();
-        }
+        //    Managers.Manager.Initialize();
+        //}
         PhotonNetwork.LoadLevel("LHJ_TestScene");
     }
 }

--- a/Assets/LHJ/LHJ_Scripts/Sync/GameOverSync.cs
+++ b/Assets/LHJ/LHJ_Scripts/Sync/GameOverSync.cs
@@ -11,7 +11,6 @@ public class GameOverSync : MonoBehaviourPunCallbacks
     [SerializeField] private GameObject gameOverPanel;
     [SerializeField] private TextMeshProUGUI winnerText;
     [SerializeField] private TextMeshProUGUI countdownText;
-    private PhotonView _pv;
     private bool hasShow = false;
 
     public static GameOverSync Instance;

--- a/Assets/LTH/Scripts/Prototype/SceneInit.cs
+++ b/Assets/LTH/Scripts/Prototype/SceneInit.cs
@@ -75,6 +75,35 @@ public class SceneInit : MonoBehaviourPunCallbacks
                 go.AddComponent<ItemBoxSpawnerManager>();
                 DontDestroyOnLoad(go);
             }
+
+            if (InGameManager.Instance == null)
+            {
+                GameObject go = new GameObject("InGameManager");
+                go.AddComponent<InGameManager>();
+                DontDestroyOnLoad(go);
+            }
+
+            if (GunManager.Instance == null)
+            {
+                GameObject go = new GameObject("GunManager");
+                go.AddComponent<GunManager>();
+                DontDestroyOnLoad(go);
+            }
+
+            if (PlayerManager.Instance == null)
+            {
+                GameObject go = new GameObject("PlayerManager");
+                go.AddComponent<PlayerManager>();
+                DontDestroyOnLoad(go);
+            }
+
+            if (ItemSyncManager.Instance == null)
+            {
+                GameObject go = new GameObject("ItemSyncManager");
+                go.AddComponent<ItemSyncManager>();
+                DontDestroyOnLoad(go);
+            }
+
             InGameManager.Instance.StartGame();
         }
             

--- a/Assets/Resources/Prefabs/GunManager.prefab
+++ b/Assets/Resources/Prefabs/GunManager.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &131890264544142879
+--- !u!1 &1875941947762760858
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,50 +8,50 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 801757680438611914}
-  - component: {fileID: 8036146403556655074}
-  - component: {fileID: 4657332672231559590}
+  - component: {fileID: 4654570947768147938}
+  - component: {fileID: 7835995504342327013}
+  - component: {fileID: 4545920831931600290}
   m_Layer: 0
-  m_Name: ItemSyncManager
+  m_Name: GunManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &801757680438611914
+--- !u!4 &4654570947768147938
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131890264544142879}
+  m_GameObject: {fileID: 1875941947762760858}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.9147198, y: 2.2424526, z: 1.3925686}
+  m_LocalPosition: {x: 0.8880852, y: 5.5914745, z: 2.010602}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8036146403556655074
+--- !u!114 &7835995504342327013
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131890264544142879}
+  m_GameObject: {fileID: 1875941947762760858}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cf0df1f4984d9674ead486465115c096, type: 3}
+  m_Script: {fileID: 11500000, guid: a3ff605b4ca0d934cb4f8c5750151898, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4657332672231559590
+--- !u!114 &4545920831931600290
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131890264544142879}
+  m_GameObject: {fileID: 1875941947762760858}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}

--- a/Assets/Resources/Prefabs/GunManager.prefab.meta
+++ b/Assets/Resources/Prefabs/GunManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 74a0b0b6be4d53444b70583f0b61f0c1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/InGameManager.prefab
+++ b/Assets/Resources/Prefabs/InGameManager.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &131890264544142879
+--- !u!1 &1627378647290176247
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,50 +8,50 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 801757680438611914}
-  - component: {fileID: 8036146403556655074}
-  - component: {fileID: 4657332672231559590}
+  - component: {fileID: 3314161308126368331}
+  - component: {fileID: 3565339042298311418}
+  - component: {fileID: 5305020070202499777}
   m_Layer: 0
-  m_Name: ItemSyncManager
+  m_Name: InGameManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &801757680438611914
+--- !u!4 &3314161308126368331
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131890264544142879}
+  m_GameObject: {fileID: 1627378647290176247}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.9147198, y: 2.2424526, z: 1.3925686}
+  m_LocalPosition: {x: 0.8880852, y: 5.5914745, z: 2.010602}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8036146403556655074
+--- !u!114 &3565339042298311418
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131890264544142879}
+  m_GameObject: {fileID: 1627378647290176247}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cf0df1f4984d9674ead486465115c096, type: 3}
+  m_Script: {fileID: 11500000, guid: 8c5bcb9e7c2028b499e2f6fe3a65ce15, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4657332672231559590
+--- !u!114 &5305020070202499777
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 131890264544142879}
+  m_GameObject: {fileID: 1627378647290176247}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}

--- a/Assets/Resources/Prefabs/InGameManager.prefab.meta
+++ b/Assets/Resources/Prefabs/InGameManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0bac792d1f4e66b47bf43b0d7e5a690a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/PlayerManager.prefab
+++ b/Assets/Resources/Prefabs/PlayerManager.prefab
@@ -9,8 +9,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 704364988821564950}
-  - component: {fileID: -9105397608597516240}
-  - component: {fileID: 3371519143914825065}
+  - component: {fileID: 5917273514279752151}
+  - component: {fileID: -3092348195253772962}
   m_Layer: 0
   m_Name: PlayerManager
   m_TagString: Untagged
@@ -33,7 +33,21 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &-9105397608597516240
+--- !u!114 &5917273514279752151
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5405539329244583951}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a7e5ff1c34585842ba9e3a25dac1d38, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _playerList: []
+  _playerDataList: []
+--- !u!114 &-3092348195253772962
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -55,20 +69,3 @@ MonoBehaviour:
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
---- !u!114 &3371519143914825065
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5405539329244583951}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3d4d9c8f1d08b6c47a75e4c4a552f5b0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _playerData:
-    nickname: 
-    playerId: 
-    winCount: 0
-    loseCount: 0


### PR DESCRIPTION
## 🔥 작업 내용 요약
- 어떤 기능을 구현했는지 간단히 설명 (셋 중에 하나 골라서 작성)
- Feature :
  - 기능 요약 : 매니저 초기화 수정
  - 구현 내용 : Manager에서 인게임에 관련된 매니저들을 AddComponent부분에서 주석처리하고 각각 프리팹화 시켜서 Item에 관련된 매니저들 처럼 GameOverSync에서 Release시키고 SceneInit에서 재생성 되게 구현 
- Bugfix :
  - 버그 내용 : 
  - 해결 방안 :
- Refactor :
  - 작업 내용 :
  - 리펙토링 의도 :
- Docs :
  - 작업 내용

## 🧪 테스트 방법
- 어떻게 테스트했는지 작성
- (ex: 에디터에서 직접 실행 / 빌드해서 확인 등)
씬은 혹시몰라서 커밋할때 안넣어놨기때문에 Resource/Prefabs파일에 GunManager, PlayerManager, InGameManager, ItemBoxSpawnerManager,  DeskUIManager, ItemSyncManager를 게임씬에 없는 매니저 프리팹을 추가하시면 됩니다
<img width="640" height="302" alt="image" src="https://github.com/user-attachments/assets/81ab6449-5919-40a5-8388-4aafbed40fb0" />

## 🤝 관련 이슈
- 관련된 이슈 번호나 작업명 (ex: `#23`)

## ✅ 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항
- 리뷰어에게 공유하고 싶은 내용
게임을 재시작할때 카메라 시점 버그 때문에 상대방 쪽에서 아이템 박스를 여는 상황입니다.
<img width="1146" height="714" alt="image" src="https://github.com/user-attachments/assets/77fe478b-ded6-4cba-b299-8a946b67be89" />

