### PR TITLE
[Fix] 발사 버튼 중복 클릭 시 연속 발사되는 현상 & 첫 턴에 탄이 순서대로 정렬되는 현상 & 총알 시각화 시 실제 장전 순서가 그대로 노출되는 현상

### DIFF
--- a/Assets/LHJ/LHJ_Scripts/Sync/FireSync.cs
+++ b/Assets/LHJ/LHJ_Scripts/Sync/FireSync.cs
@@ -32,7 +32,6 @@ public class FireSync : MonoBehaviourPun
             var current = GunManager.Instance.Magazine.ToArray();
             var bullets = new List<int> { (int)GunManager.Instance.LoadedBullet };
             bullets.AddRange(Array.ConvertAll(current, b => (int)b));
-            bullets.Sort((a, b) => b.CompareTo(a));
 
             photonView.RPC("ReloadSync", RpcTarget.All, bullets.ToArray(), bullets[0]);
         }

--- a/Assets/LTH/Scripts/UI/UI_GunController.cs
+++ b/Assets/LTH/Scripts/UI/UI_GunController.cs
@@ -18,6 +18,8 @@ public class UI_GunController : MonoBehaviour
     /// </summary>
     private string myId;
 
+    private bool isFiring = false; // 발사 중인지 여부
+
     private void Start()
     {
         myId = PhotonNetwork.NickName;
@@ -41,21 +43,29 @@ public class UI_GunController : MonoBehaviour
 
     private void Update()
     {
-        // 내 턴일 때만 버튼 활성화
-        fireButton.interactable = (TurnSync.CurrentTurnPlayerId == myId);
+        // 발사 중이 아닐 때만 버튼 활성화
+        fireButton.interactable = !isFiring && TurnSync.CurrentTurnPlayerId == myId;
     }
 
     private void OnFireButtonClicked()
     {
-        //중복 클릭 방지를 위해 누르자마자 interactable 차단
-        fireButton.interactable = false;
-        
-        
+        if (isFiring)
+        {
+            Debug.LogWarning("[FireButtonController] 이미 발사 처리 중 → 무시");
+            return;
+        }
+
         if (TurnSync.CurrentTurnPlayerId != myId)
         {
             Debug.LogWarning("[FireButtonController] 내 턴이 아님 → 발사 안 됨");
             return;
         }
+
+        isFiring = true;
+
+        //중복 클릭 방지를 위해 누르자마자 interactable 차단
+        fireButton.interactable = false;
+        
         fireSync.photonView.RPC("RequestFire", RpcTarget.MasterClient, myId);
     }
 
@@ -66,6 +76,10 @@ public class UI_GunController : MonoBehaviour
         targetId = Util_LDH.GetUserNickname(targetId);
         
         Debug.Log($"[HandlePlayerHit] 내 클라이언트에서 호출됨 → {targetId}, {bullet}");
+
+        // 발사 완료 처리
+        isFiring = false;
+
         if (hitMessageText == null) return;
 
         string result = bullet == BulletType.live


### PR DESCRIPTION
## 🔥 작업 내용 요약
- 어떤 기능을 구현했는지 간단히 설명 (셋 중에 하나 골라서 작성)
- Bugfix :
  - 버그 내용 : 발사 버튼 중복 클릭 시 연속 발사되는 현상
`fireButton.interactable = false`로 일시적으로 비활성화되지만,  
`Update()`에서 `TurnSync.CurrentTurnPlayerId == myId` 조건만으로 버튼이 다시 활성화되어 중복해서 발사되는 것으로 보임
    - 해결 방안 : 중복 발사 방지를 위해 isFiring 를 추가하여,  발사 중에는 버튼이 다시 활성화되지 않도록 제어

  - 버그 내용 :  첫 턴에 탄이 순서대로 정렬되는 현상
  `bullets.Sort((a, b) => b.CompareTo(a));` 불필요한 정렬 부분이 있어 문제가 생긴 것으로 보임
    - 해결 방안 : 해당 코드 삭제

  - 버그 내용 :  총알 시각화 시 실제 장전 순서가 그대로 노출되는 현상
  탄정보를 그대로 받아서 `for (int i = 0; i < syncedBullets.Count; i++)` 순서대로 나열되는 코드 때문에 발생한 원인임
    - 해결 방안 : 실탄 프리팹 n개, 공포탄 프리팹 m개를 종류별로 묶어서 나열하도록 수정

## ✅ 체크리스트
- [x] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항
일단 돋보기 기능 작동은 잘 되고 있는 것 확인했습니다.