### PR TITLE
플레이어 애니메이션 적용 / UI 호버링 설명 창 껏 다 켜졌다 하는 버그 해결

### DIFF
--- a/Assets/PMS/PMS_Animator/Player.controller
+++ b/Assets/PMS/PMS_Animator/Player.controller
@@ -91,7 +91,7 @@ AnimatorController:
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
-    m_DefaultBool: 1
+    m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
   - m_Name: Hit
     m_Type: 9
@@ -126,9 +126,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0.08131266
   m_TransitionOffset: 0
-  m_ExitTime: 0.5
+  m_ExitTime: 0.2368641
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -234,9 +234,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_TransitionDuration: 0.012099564
+  m_TransitionOffset: 0.009671565
+  m_ExitTime: 0.02781164
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0

--- a/Assets/PMS/PMS_Scene/PMS_InGame.unity
+++ b/Assets/PMS/PMS_Scene/PMS_InGame.unity
@@ -49371,7 +49371,7 @@ Transform:
   m_GameObject: {fileID: 1299948552}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
-  m_LocalPosition: {x: 11.891, y: 9.1779995, z: 2.34}
+  m_LocalPosition: {x: 11.891, y: 9.1779995, z: 2.42}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -55182,7 +55182,7 @@ Camera:
     height: 1
   near clip plane: 0.3
   far clip plane: 1000
-  field of view: 55.000004
+  field of view: 55
   orthographic: 0
   orthographic size: 5
   m_Depth: 0

--- a/Assets/Resources/Prefabs/UI/Global/UI_InventoryInfo.prefab
+++ b/Assets/Resources/Prefabs/UI/Global/UI_InventoryInfo.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -308,7 +308,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:


### PR DESCRIPTION
## 🔥 작업 내용 요약
- Feature :
  - 기능 요약 : 플레이어 애니메이션 공격,피격 타이밍 수정
  - 구현 내용 : 애니메이션 공격과 피격간의 자연스러운 타이밍 총이 발사되는 타이밍때 맞도록 애니메이션 Animation Trasition 조정
- Bugfix :
  - 버그 내용 : UI 호버링 설명창 껏다 켜졌다 하는 버그 
  - 해결 방안 : UI_InventoryInfo의 ItemName,Description의 Extra Setting - Ray Cast Target 체크해제

## 🧪 테스트 방법
- 패럴싱크
- 
## 🤝 관련 이슈

## ✅ 체크리스트
- [ ] 빌드 오류 없음
- [ ] 기능 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수
- [ ] Scene 충돌 없음

## 💬 기타 사항


