### PR TITLE
[Fix] 목숨 5개로 늘림

### DIFF
--- a/Assets/LDH/LDH_Prefabs/UI_NickNamePanel.prefab
+++ b/Assets/LDH/LDH_Prefabs/UI_NickNamePanel.prefab
@@ -2957,7 +2957,7 @@ PrefabInstance:
     - target: {fileID: 114594570875668262, guid: a77e2c4748edcd5429717838a8f70fb0,
         type: 3}
       propertyPath: m_ContentType
-      value: 4
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114594570875668262, guid: a77e2c4748edcd5429717838a8f70fb0,
         type: 3}
@@ -2967,12 +2967,12 @@ PrefabInstance:
     - target: {fileID: 114594570875668262, guid: a77e2c4748edcd5429717838a8f70fb0,
         type: 3}
       propertyPath: m_KeyboardType
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114594570875668262, guid: a77e2c4748edcd5429717838a8f70fb0,
         type: 3}
       propertyPath: m_CharacterValidation
-      value: 4
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114987855375207344, guid: a77e2c4748edcd5429717838a8f70fb0,
         type: 3}

--- a/Assets/LDH/LDH_Scenes/LDH_SoundTestScene.unity
+++ b/Assets/LDH/LDH_Scenes/LDH_SoundTestScene.unity
@@ -140,7 +140,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &126092905
 RectTransform:
   m_ObjectHideFlags: 0
@@ -591,6 +591,123 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 462679606}
   m_CullTransparentMesh: 1
+--- !u!1001 &798723855
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9973214
+      objectReference: {fileID: 0}
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.05790151
+      objectReference: {fileID: 0}
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.044616852
+      objectReference: {fileID: 0}
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.002590317
+      objectReference: {fileID: 0}
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 6.645
+      objectReference: {fileID: 0}
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 5.123
+      objectReference: {fileID: 0}
+    - target: {fileID: 546629862798169066, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2540084848652757635, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 849390030}
+    - target: {fileID: 2540084848652757635, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: PlayFire
+      objectReference: {fileID: 0}
+    - target: {fileID: 2540084848652757635, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: SfxPlayTest, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 2540084848652757635, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 9011387273193290289, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      propertyPath: m_Name
+      value: we
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 9011387273193290289, guid: d0469d51531994692b4079f6124b4f30,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 798723857}
+  m_SourcePrefab: {fileID: 100100000, guid: d0469d51531994692b4079f6124b4f30, type: 3}
+--- !u!1 &798723856 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9011387273193290289, guid: d0469d51531994692b4079f6124b4f30,
+    type: 3}
+  m_PrefabInstance: {fileID: 798723855}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &798723857
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 798723856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 397a03b8336d41d7a35a2b1ddbcd3054, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ui: {fileID: 840036989}
+--- !u!224 &840036989 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5817801177782380680, guid: d0469d51531994692b4079f6124b4f30,
+    type: 3}
+  m_PrefabInstance: {fileID: 798723855}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &849390025
 GameObject:
   m_ObjectHideFlags: 0
@@ -727,7 +844,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &859272498
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1107,7 +1224,7 @@ PrefabInstance:
     - target: {fileID: 6656097000227697414, guid: bd2d7a1e76a47ef4e87bad63cfc6beef,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -2.773
       objectReference: {fileID: 0}
     - target: {fileID: 6656097000227697414, guid: bd2d7a1e76a47ef4e87bad63cfc6beef,
         type: 3}
@@ -1198,3 +1315,4 @@ SceneRoots:
   - {fileID: 323052640}
   - {fileID: 1817649944}
   - {fileID: 1264450993}
+  - {fileID: 798723855}

--- a/Assets/LDH/LDH_Scenes/Lobby.unity
+++ b/Assets/LDH/LDH_Scenes/Lobby.unity
@@ -1757,7 +1757,7 @@ PrefabInstance:
     - target: {fileID: 2940185959135385265, guid: 7a3bb046137d141a49ec32d2dd646018,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 217.6
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2940185959135385265, guid: 7a3bb046137d141a49ec32d2dd646018,
         type: 3}
@@ -1984,7 +1984,7 @@ PrefabInstance:
     - target: {fileID: 195407178480788838, guid: 18780d368d1c54a7e981c1d6d2e9cfda,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 271.35
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 195407178480788838, guid: 18780d368d1c54a7e981c1d6d2e9cfda,
         type: 3}
@@ -2354,6 +2354,16 @@ PrefabInstance:
     - target: {fileID: 1802591251912534851, guid: d1326ed455cd94f1eb620cfa4548e8dd,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1986041071656740645, guid: d1326ed455cd94f1eb620cfa4548e8dd,
+        type: 3}
+      propertyPath: m_KeyboardType
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1986041071656740645, guid: d1326ed455cd94f1eb620cfa4548e8dd,
+        type: 3}
+      propertyPath: m_CharacterValidation
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3434893717018517098, guid: d1326ed455cd94f1eb620cfa4548e8dd,

--- a/Assets/LDH/LDH_Scenes/we.prefab
+++ b/Assets/LDH/LDH_Scenes/we.prefab
@@ -1,0 +1,339 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2447363480995584347
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5817801177782380680}
+  - component: {fileID: 5201936142457941632}
+  - component: {fileID: 8946957614632667305}
+  - component: {fileID: 7439325351383098420}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5817801177782380680
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2447363480995584347}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4258142672303926177}
+  m_Father: {fileID: 546629862798169066}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &5201936142457941632
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2447363480995584347}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &8946957614632667305
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2447363480995584347}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &7439325351383098420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2447363480995584347}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &6517023214327343282
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4258142672303926177}
+  - component: {fileID: 8883518702548295634}
+  - component: {fileID: 7551650446524195337}
+  - component: {fileID: 2540084848652757635}
+  m_Layer: 5
+  m_Name: RawImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4258142672303926177
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6517023214327343282}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5817801177782380680}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8883518702548295634
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6517023214327343282}
+  m_CullTransparentMesh: 1
+--- !u!114 &7551650446524195337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6517023214327343282}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!114 &2540084848652757635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6517023214327343282}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7551650446524195337}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 9011387273193290289}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &9011387273193290289
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 546629862798169066}
+  - component: {fileID: 4699430752923466170}
+  - component: {fileID: 3822074669327864353}
+  - component: {fileID: 2765200777063025516}
+  m_Layer: 0
+  m_Name: we
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &546629862798169066
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9011387273193290289}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.05790151, y: 0.044616852, z: -0.002590317, w: 0.9973214}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5817801177782380680}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 6.645, y: 5.123, z: 0}
+--- !u!33 &4699430752923466170
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9011387273193290289}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3822074669327864353
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9011387273193290289}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &2765200777063025516
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9011387273193290289}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/LDH/LDH_Scenes/we.prefab.meta
+++ b/Assets/LDH/LDH_Scenes/we.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d0469d51531994692b4079f6124b4f30
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LDH/LDH_Scripts/Test/UITest.cs
+++ b/Assets/LDH/LDH_Scripts/Test/UITest.cs
@@ -8,26 +8,17 @@ namespace Test
 {
     public class UITest : MonoBehaviour
     {
-        private UI_Base settingUI;
+        [SerializeField] private Transform ui;
 
+        private Camera _camera;
         private void Start()
         {
-            settingUI = Manager.UI.GetGlobalUI(Define_LDH.GlobalUI.UI_Setting);
+            _camera = Camera.main;
         }
 
-        private void Update()
+        private void LateUpdate()
         {
-            if(Input.GetKeyDown(KeyCode.Escape))
-            {
-                if (!settingUI.gameObject.activeSelf)
-                {
-                    Manager.UI.ShowGlobalUI(Define_LDH.GlobalUI.UI_Setting);
-                }
-                else
-                {
-                    Manager.UI.CloseGlobalUI(Define_LDH.GlobalUI.UI_Setting);
-                }
-            }
+            ui.transform.forward = _camera.transform.forward;
         }
     }
 }

--- a/Assets/LDH/LDH_Scripts/UI/UI_Content/UI_Setting.cs
+++ b/Assets/LDH/LDH_Scripts/UI/UI_Content/UI_Setting.cs
@@ -72,6 +72,8 @@ namespace GameUI
         {
             if (PhotonNetwork.IsConnected && PhotonNetwork.InRoom)
             {
+                if(InGameManager.Instance!=null && !InGameManager.Instance.IsGameOver)
+                
                 //방 나가기
                 PhotonNetwork.LeaveRoom(false);
                 Close();

--- a/Assets/LTH/LTH_Image/HeartImage.prefab
+++ b/Assets/LTH/LTH_Image/HeartImage.prefab
@@ -34,8 +34,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.026, y: -0.051}
-  m_SizeDelta: {x: 0.1, y: 0.1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 2, y: 2}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3304538007892270073
 CanvasRenderer:
@@ -67,7 +67,7 @@ MonoBehaviour:
       m_Calls: []
   m_Sprite: {fileID: 21300000, guid: e5438c93f4034e946b6352ec89a0a84e, type: 3}
   m_Type: 0
-  m_PreserveAspect: 0
+  m_PreserveAspect: 1
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1

--- a/Assets/PMS/PMS_Scene/PMS_InGame.unity
+++ b/Assets/PMS/PMS_Scene/PMS_InGame.unity
@@ -5809,6 +5809,141 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6ced95f04487bec4e81f51a934884b80, type: 3}
+--- !u!1 &138088962
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 138088963}
+  - component: {fileID: 138088965}
+  - component: {fileID: 138088964}
+  m_Layer: 5
+  m_Name: NicknameText2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &138088963
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 138088962}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0259}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 476703700}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.1754, y: 0.065999985}
+  m_SizeDelta: {x: 0.52264, y: 0.0946}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &138088964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 138088962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uD55C\uAE00 \uC774\uB984"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 4bd810f1cbcb0f446a8f5a31453e243f, type: 2}
+  m_sharedMaterial: {fileID: 21539420542967178, guid: 4bd810f1cbcb0f446a8f5a31453e243f,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 0.04
+  m_fontSizeBase: 0.04
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0.09664755, y: 0, z: 0.04454626, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &138088965
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 138088962}
+  m_CullTransparentMesh: 1
 --- !u!4 &138169128 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4563883862551582, guid: 6fc86bcd020904044a931af912652050,
@@ -18490,6 +18625,111 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 476279649}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &476703699
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 476703700}
+  - component: {fileID: 476703703}
+  - component: {fileID: 476703702}
+  - component: {fileID: 476703701}
+  m_Layer: 5
+  m_Name: PlayerHPCanvas (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &476703700
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476703699}
+  m_LocalRotation: {x: -0, y: -1, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0.095}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 974119223}
+  - {fileID: 138088963}
+  - {fileID: 971204090}
+  - {fileID: 1952660101}
+  m_Father: {fileID: 524271593}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0.32849002}
+  m_SizeDelta: {x: 0.74, y: 0.2299}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &476703701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476703699}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &476703702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476703699}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!223 &476703703
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476703699}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!4 &477309157 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4753445397855558, guid: 14fe2334655920c41b766609db0e8e79,
@@ -19731,8 +19971,13 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 130389234106264615, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.3109
+      objectReference: {fileID: 0}
+    - target: {fileID: 130389234106264615, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.409
+      value: -1.262
       objectReference: {fileID: 0}
     - target: {fileID: 130389234106264615, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
@@ -19742,7 +19987,7 @@ PrefabInstance:
     - target: {fileID: 130389234106264615, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.753
+      value: 0.816
       objectReference: {fileID: 0}
     - target: {fileID: 130389234106264615, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
@@ -19784,11 +20029,16 @@ PrefabInstance:
       propertyPath: m_Name
       value: PlayerHPUI
       objectReference: {fileID: 0}
-    - target: {fileID: 757991212295665309, guid: b07caef7e8e26b047820944d888743b8,
+    - target: {fileID: 4359802767783661083, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6481279013788044226, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: myHPPanel
+      value: 
+      objectReference: {fileID: 971204090}
     - target: {fileID: 6481279013788044226, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
       propertyPath: winnerText
@@ -19796,14 +20046,40 @@ PrefabInstance:
       objectReference: {fileID: 309891544788875859}
     - target: {fileID: 6481279013788044226, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
+      propertyPath: enemyHPPanel
+      value: 
+      objectReference: {fileID: 1952660101}
+    - target: {fileID: 6481279013788044226, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
       propertyPath: gameOverPanel
       value: 
       objectReference: {fileID: 8395159398648221000}
+    - target: {fileID: 6481279013788044226, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: myNicknameText
+      value: 
+      objectReference: {fileID: 974119224}
+    - target: {fileID: 6481279013788044226, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: enemyNicknameText
+      value: 
+      objectReference: {fileID: 138088964}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 4359802767783661083, guid: b07caef7e8e26b047820944d888743b8, type: 3}
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 130389234106264615, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 476703700}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b07caef7e8e26b047820944d888743b8, type: 3}
+--- !u!4 &524271593 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 130389234106264615, guid: b07caef7e8e26b047820944d888743b8,
+    type: 3}
+  m_PrefabInstance: {fileID: 524271592}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &524372373
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -36875,6 +37151,108 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 334495707}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &971204089
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 971204090}
+  - component: {fileID: 971204093}
+  - component: {fileID: 971204092}
+  - component: {fileID: 971204091}
+  m_Layer: 5
+  m_Name: HPPanel1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &971204090
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971204089}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.000000029802322}
+  m_LocalScale: {x: 0.03, y: 0.03, z: 0.03}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 476703700}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -0.000000029802322, y: 0.008}
+  m_SizeDelta: {x: 12.15955, y: 3.8}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &971204091
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971204089}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 1
+    m_Right: 1
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 1
+  m_ChildScaleHeight: 1
+  m_ReverseArrangement: 0
+--- !u!114 &971204092
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971204089}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 3782141a7e3b4b947ba8d317cd1b299f, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &971204093
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971204089}
+  m_CullTransparentMesh: 1
 --- !u!1001 &971741175
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -36979,6 +37357,141 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1302585504}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &974119222
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 974119223}
+  - component: {fileID: 974119225}
+  - component: {fileID: 974119224}
+  m_Layer: 5
+  m_Name: NicknameText1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &974119223
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974119222}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0068000257}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 476703700}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -0.37, y: 0.11495}
+  m_SizeDelta: {x: 0.35647, y: 0.0946}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &974119224
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974119222}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: d
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 4bd810f1cbcb0f446a8f5a31453e243f, type: 2}
+  m_sharedMaterial: {fileID: 21539420542967178, guid: 4bd810f1cbcb0f446a8f5a31453e243f,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 0.04
+  m_fontSizeBase: 0.04
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0.0076516154, y: 0, z: 0.002852872, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &974119225
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974119222}
+  m_CullTransparentMesh: 1
 --- !u!1001 &975037746
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -64322,6 +64835,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 130389234106264615, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.3109
+      objectReference: {fileID: 0}
+    - target: {fileID: 130389234106264615, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: -1.214
       objectReference: {fileID: 0}
@@ -64380,15 +64898,45 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3131950964076129349, guid: b07caef7e8e26b047820944d888743b8,
+    - target: {fileID: 868787931330672598, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
-      propertyPath: m_ChildScaleWidth
+      propertyPath: m_SizeDelta.x
+      value: 0.74
+      objectReference: {fileID: 0}
+    - target: {fileID: 868787931330672598, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.095
+      objectReference: {fileID: 0}
+    - target: {fileID: 868787931330672598, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3131950964076129349, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
+      propertyPath: m_ChildAlignment
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3131950964076129349, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Padding.m_Left
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3131950964076129349, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_ChildScaleWidth
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3131950964076129349, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Padding.m_Right
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3131950964076129349, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
       propertyPath: m_ChildScaleHeight
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3131950964076129349, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
@@ -64403,22 +64951,366 @@ PrefabInstance:
     - target: {fileID: 3131950964076129349, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
       propertyPath: m_ChildForceExpandWidth
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3131950964076129349, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
       propertyPath: m_ChildForceExpandHeight
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 12.15955
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 3.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.000000029802322
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.000000029802322
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.008
+      objectReference: {fileID: 0}
+    - target: {fileID: 3247706408777045534, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_ConstrainProportionsScale
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 12.4947
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 3.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.03
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.0000002682209
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.000000059604645
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.008
+      objectReference: {fileID: 0}
+    - target: {fileID: 3992932441671757130, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0.36714
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0.0946
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.0068000257
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.37
+      objectReference: {fileID: 0}
+    - target: {fileID: 4089714828977701110, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.11495
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641661919393911059, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0.52264
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641661919393911059, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0.0946
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641661919393911059, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.0259
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641661919393911059, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641661919393911059, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641661919393911059, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641661919393911059, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0.1754
+      objectReference: {fileID: 0}
+    - target: {fileID: 4641661919393911059, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.065999985
       objectReference: {fileID: 0}
     - target: {fileID: 5082058292483095425, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
       propertyPath: m_text
+      value: "\uC774\uB984"
+      objectReference: {fileID: 0}
+    - target: {fileID: 5082058292483095425, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 0.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 5082058292483095425, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_margin.x
+      value: -0.0008514893
+      objectReference: {fileID: 0}
+    - target: {fileID: 5082058292483095425, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_margin.z
+      value: 0.0076460093
+      objectReference: {fileID: 0}
+    - target: {fileID: 5082058292483095425, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_fontAsset
       value: 
+      objectReference: {fileID: 11400000, guid: 4bd810f1cbcb0f446a8f5a31453e243f,
+        type: 2}
+    - target: {fileID: 5082058292483095425, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 0.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 5082058292483095425, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_overflowMode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5082058292483095425, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: 21539420542967178, guid: 4bd810f1cbcb0f446a8f5a31453e243f,
+        type: 2}
+    - target: {fileID: 5082058292483095425, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6005705308035016793, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
       propertyPath: m_text
+      value: "\uC774\uB984"
+      objectReference: {fileID: 0}
+    - target: {fileID: 6005705308035016793, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 0.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 6005705308035016793, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_fontAsset
       value: 
+      objectReference: {fileID: 11400000, guid: 4bd810f1cbcb0f446a8f5a31453e243f,
+        type: 2}
+    - target: {fileID: 6005705308035016793, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 0.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 6005705308035016793, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_overflowMode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6005705308035016793, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: 21539420542967178, guid: 4bd810f1cbcb0f446a8f5a31453e243f,
+        type: 2}
+    - target: {fileID: 6005705308035016793, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6481279013788044226, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
@@ -64432,6 +65324,31 @@ PrefabInstance:
       objectReference: {fileID: 8395159398648221000}
     - target: {fileID: 8275670916197607616, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
+      propertyPath: m_ChildAlignment
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8275670916197607616, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Padding.m_Left
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8275670916197607616, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_ChildScaleWidth
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8275670916197607616, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_Padding.m_Right
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8275670916197607616, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
+      propertyPath: m_ChildScaleHeight
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8275670916197607616, guid: b07caef7e8e26b047820944d888743b8,
+        type: 3}
       propertyPath: m_ChildControlWidth
       value: 0
       objectReference: {fileID: 0}
@@ -64443,12 +65360,12 @@ PrefabInstance:
     - target: {fileID: 8275670916197607616, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
       propertyPath: m_ChildForceExpandWidth
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8275670916197607616, guid: b07caef7e8e26b047820944d888743b8,
         type: 3}
       propertyPath: m_ChildForceExpandHeight
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -77217,6 +78134,108 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1077421159}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1952660100
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1952660101}
+  - component: {fileID: 1952660104}
+  - component: {fileID: 1952660103}
+  - component: {fileID: 1952660102}
+  m_Layer: 5
+  m_Name: HPPanel2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1952660101
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1952660100}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0000002682209}
+  m_LocalScale: {x: 0.03, y: 0.03, z: 0.03}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 476703700}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -0.000000059604645, y: 0.008}
+  m_SizeDelta: {x: 12.4947, y: 3.8}
+  m_Pivot: {x: 1, y: 0}
+--- !u!114 &1952660102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1952660100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 1
+    m_Right: 1
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 1
+  m_ChildScaleHeight: 1
+  m_ReverseArrangement: 0
+--- !u!114 &1952660103
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1952660100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 3782141a7e3b4b947ba8d317cd1b299f, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1952660104
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1952660100}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1952956457
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/PMS/PMS_Scripts/GamePlayer.cs
+++ b/Assets/PMS/PMS_Scripts/GamePlayer.cs
@@ -141,7 +141,7 @@ public class GamePlayer : MonoBehaviourPun, IComparer<GamePlayer>
     //프로퍼티 사용해서 이벤트 호출하게 해야함 - UI를 위해서
     public void Initialize()
     {
-        MaxHp = 3;
+        MaxHp = 5;
         CurrentHp = MaxHp;
         IsAlive = true;
     }


### PR DESCRIPTION
## 🔥 작업 내용 요약
- 어떤 기능을 구현했는지 간단히 설명 (셋 중에 하나 골라서 작성)
- Feature :
  - 기능 요약 : 목숨 3개 -> 5개로 증가
  - 구현 내용 : 라운드가 하나밖에 없어서 목숨을 5개로 늘렸습니다. 이에 따라 player hp ui의 크기 조정 및 하트 이미지 프리팹 default 사이즈 조정 등 폴리싱을 진행했습니다.


## 🧪 테스트 방법
실행했을 때 양쪽에서 모두 하트가 5개씩 나오는지 확인

## 🤝 관련 이슈
- 관련된 이슈 번호나 작업명 (ex: `#23`)

## ✅ 체크리스트
- [ ] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항
asset repositiory에 한글용 폰트 에셋을 올려두었습니다. open sans가 영문만 지원되고 있는데 open sans에서 fallback 나는 경우 NotoSansKR로 대체하도록 open sans의 각 폰트 에셋 설정을 변경했습니다. asset repository에서 변경 내역 다운받으면 바로 적용됩니다.
