### PR TITLE
[QA] 애니메이션 impulse 오류, target ui setactive 오류 수정

### DIFF
--- a/Assets/CYE/CYE_Prefabs/TargetSelectUI.prefab
+++ b/Assets/CYE/CYE_Prefabs/TargetSelectUI.prefab
@@ -151,7 +151,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &4912553547351428360
 RectTransform:
   m_ObjectHideFlags: 0
@@ -185,12 +185,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 11cf718dba01ed44385cc44dbc0a53d8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _targetSpawnPoint:
-  - {fileID: 0}
-  - {fileID: 0}
   _targetButtonArray:
   - {fileID: 7367888901692560347}
   - {fileID: 3298496497866794282}
+  _fireSync: {fileID: 0}
+  _gunController: {fileID: 0}
 --- !u!1 &3298496497866794282
 GameObject:
   m_ObjectHideFlags: 0
@@ -228,7 +227,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 50}
   m_SizeDelta: {x: 300, y: 150}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &3635863548583152883
@@ -510,7 +509,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -50}
   m_SizeDelta: {x: 300, y: 150}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &3952530099011324772

--- a/Assets/CYE/CYE_Scripts/GunController.cs
+++ b/Assets/CYE/CYE_Scripts/GunController.cs
@@ -37,6 +37,7 @@ public class GunController : MonoBehaviourPun
         var targetUI = FindObjectOfType<TargetSelectUI>(true);
         targetUI.SetGunController(this);
         _targetSelectUI = targetUI.gameObject;
+        targetUI.gameObject.SetActive(false);
     }
     void OnMouseDown()
     {

--- a/Assets/LDH/LDH_Resource/SelfShot.anim
+++ b/Assets/LDH/LDH_Resource/SelfShot.anim
@@ -47729,7 +47729,7 @@ AnimationClip:
     intParameter: 0
     messageOptions: 0
   - time: 1.2666667
-    functionName: GunImpulse
+    functionName: OnGunImpuse
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/LDH/LDH_Scenes/Lobby.unity
+++ b/Assets/LDH/LDH_Scenes/Lobby.unity
@@ -1757,7 +1757,7 @@ PrefabInstance:
     - target: {fileID: 2940185959135385265, guid: 7a3bb046137d141a49ec32d2dd646018,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 217.6
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2940185959135385265, guid: 7a3bb046137d141a49ec32d2dd646018,
         type: 3}
@@ -1984,7 +1984,7 @@ PrefabInstance:
     - target: {fileID: 195407178480788838, guid: 18780d368d1c54a7e981c1d6d2e9cfda,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 271.35
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 195407178480788838, guid: 18780d368d1c54a7e981c1d6d2e9cfda,
         type: 3}
@@ -2324,7 +2324,7 @@ PrefabInstance:
     - target: {fileID: 1569577622350725786, guid: d1326ed455cd94f1eb620cfa4548e8dd,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 95.98
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1569577622350725786, guid: d1326ed455cd94f1eb620cfa4548e8dd,
         type: 3}

--- a/Assets/PMS/PMS_Animator/Gunplay.anim
+++ b/Assets/PMS/PMS_Animator/Gunplay.anim
@@ -52265,7 +52265,7 @@ AnimationClip:
     intParameter: 0
     messageOptions: 0
   - time: 1.5833334
-    functionName: PlayShotSFX
+    functionName: OnGunImpuse
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/PMS/PMS_Animator/Hit.anim
+++ b/Assets/PMS/PMS_Animator/Hit.anim
@@ -54814,7 +54814,7 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 0.18333334
-    functionName: GunImpulse
+    functionName: OnGunImpuse
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Assets/PMS/PMS_Scripts/PlayerController.cs
+++ b/Assets/PMS/PMS_Scripts/PlayerController.cs
@@ -230,7 +230,6 @@ public class PlayerController : MonoBehaviourPun
 
     public void OnEndAnimation()
     {
-        Debug.Log("asdfasfasfasfdf");
         if (!PhotonNetwork.IsMasterClient)
             return;
         StartCoroutine(DelayAndTurnEnd());


### PR DESCRIPTION
## 🔥 작업 내용 요약
- 어떤 기능을 구현했는지 간단히 설명 (셋 중에 하나 골라서 작성)

- Bugfix :
  - 버그 내용 : 공포탄, 실탄을 남/나한테 쏠 때 impulse가 이상하게 작동되는 오류 해결
  - 해결 방안 : 애니메이션 키프레임이 잘못들어가있어서 전부 수정했습니다.

  - 버그 내용 : 실수로 target ui를 꺼주는 코드를 삭제해서 인게임 들어가자마자 타겟 ui가 뜨는 문제
  - 해결 방안 : target ui 참조 후 set active 해주는 코드 삽입


## 🧪 테스트 방법
로비에서부터 게임 오버까지 진행했을 때 문제없었음

## 🤝 관련 이슈
- 관련된 이슈 번호나 작업명 (ex: `#23`)

## ✅ 체크리스트
- [ ] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항
- 리뷰어에게 공유하고 싶은 내용

